### PR TITLE
always upgrade step-cli to specified version

### DIFF
--- a/roles/step_bootstrap_host/tasks/check.yml
+++ b/roles/step_bootstrap_host/tasks/check.yml
@@ -7,15 +7,6 @@
       - step_bootstrap_fingerprint | length > 0
   when: ansible_version.string is version('2.11.1', '<')
 
-- name: Look for step_cli_executable # noqa command-instead-of-shell
-  #"command" is a shell builtin, hence the need for the shell module
-  shell: "command -v {{ step_cli_executable }}"
-  register: step_cli_install
-  # dash (Debian sh shell) uses 127 instead of 1 for not found errors
-  failed_when: step_cli_install.rc not in [0,1,127]
-  changed_when: no
-  check_mode: no
-- name: Install step_cli
+- name: Install step_cli # always run this, to ensure our cli version is up-to-date
   include_role:
     name: maxhoesel.smallstep.step_cli
-  when: step_cli_install.rc != 0

--- a/roles/step_ca/tasks/check.yml
+++ b/roles/step_ca/tasks/check.yml
@@ -35,16 +35,8 @@
   set_fact:
     step_ca_intermediate_password: "{{ step_ca_root_password }}"
   when: not step_ca_intermediate_password is defined
+  no_log: yes
 
-- name: Look for step_cli_executable # noqa command-instead-of-shell
-  #"command" is a shell builtin, hence the need for the shell module
-  shell: "command -v {{ step_cli_executable }}"
-  register: step_cli_install
-  # dash (Debian sh shell) uses 127 instead of 1 for not found errors
-  failed_when: step_cli_install.rc not in [0,1,127]
-  changed_when: no
-  check_mode: no
-- name: Install step_cli
+- name: Install step_cli # always run this, to ensure our cli version is also up-to-date
   include_role:
     name: maxhoesel.smallstep.step_cli
-  when: step_cli_install.rc != 0


### PR DESCRIPTION
This change ensures that step-cli is *always* at the version specified in the role variables.

Previously, this collection would not upgrade step-cli if a version was already installed. By removing this check, we always upgrade to the desired version