### PR TITLE
prevent step-renew from endlessly restarting

### DIFF
--- a/roles/step_acme_cert/templates/step-renew.service.j2
+++ b/roles/step_acme_cert/templates/step-renew.service.j2
@@ -1,7 +1,8 @@
 [Unit]
 Description=Step TLS Renewer
 After=network.target
-StartLimitIntervalSec=0
+StartLimitInterval=600
+StartLimitBurst=5
 
 [Service]
 Type=simple


### PR DESCRIPTION
This patch limits the amount of restarts the step-renew service can go through in a given time period before becoming marked as "failed".

This prevents a nasty situation where the service would endlessly restart, for example due to an already exipred certificate