### PR TITLE
Fix "cannot create regular file: '/usr/bin/step-cli|ca' Text file busy" errors when upgrading step-cli/ca

### DIFF
--- a/roles/step_ca/handlers/main.yml
+++ b/roles/step_ca/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: restart step-ca
+  systemd:
+    name: step-ca.service
+    state: restarted

--- a/roles/step_ca/tasks/install.yml
+++ b/roles/step_ca/tasks/install.yml
@@ -27,18 +27,13 @@
         remote_src: yes
       retries: 3
       delay: 3
-    # step-ca needs to be stopped in order to overwrite the executable
-    - name: Stop step-ca process
-      systemd:
-        name: step-ca
-        state: stopped
-      when: step_ca_present.stat.exists
     - name: Install step-ca binary # noqa no-changed-when
       shell: >
         set -o pipefail &&
-        cp /tmp/step-ca_{{ step_ca_version }}/bin/* {{ step_ca_executable | dirname }}
+        mv /tmp/step-ca_{{ step_ca_version }}/bin/* {{ step_ca_executable | dirname }}
       args:
         executable: /bin/bash
+      notify: restart step-ca
   always:
     - name: Remove step release archive
       file:

--- a/roles/step_cli/tasks/install.yml
+++ b/roles/step_cli/tasks/install.yml
@@ -25,7 +25,7 @@
     - name: Install step-cli binary # noqa no-changed-when
       shell: >
         set -o pipefail &&
-        cp /tmp/step_{{ step_cli_version }}/bin/step {{ step_cli_executable }}
+        mv /tmp/step_{{ step_cli_version }}/bin/step {{ step_cli_executable }}
       args:
         executable: /bin/bash
   always:


### PR DESCRIPTION
This fixes an error that can pop up when we upgrade step-cli/ca while another process is using that executable (such as the step-renew service used in `step_acme_cert`): Instead of copying the new executable (which tries to overwrite it in place, we instead move the new executable to its destination. This causes the old executable to be `unlik()`ed, meaning that the existing processes can still use the old executable in memory while the file on disk changes.

As a side effect, this also makes the step-ca upgrade a bit more seamless, as we no longer have to shut down the service before even installing the new executable.