### PR TITLE
make step-cli/ca install dir user-selectable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Below you will find the information needed to contribute to this project.
 
-Note that by contributing to this collection, you agree with the code of conduct you can find [here.](CODE_OF_CONDUCT.md)
+Note that by contributing to this collection, you agree with the code of conduct you can find [here.](/CODE_OF_CONDUCT.md)
 
 ## Requirements
 

--- a/roles/step_bootstrap_host/README.md
+++ b/roles/step_bootstrap_host/README.md
@@ -1,10 +1,10 @@
 # maxhoesel.smallstep.step_bootstrap_host
 
-Configure a host to trust your CA and install `step-cli` to access it.
+Install `step-cli` on a host and configure it to trust your CA.
+This is intended as a one-stop role that sets up all the components neccessary for using `step-cli` on a given host.
+It will:
 
-This role is intended to be run on regular hosts in your network that you want to cooperate with your existing CA. It will:
-
-1. Install `step-cli` if required
+1. Install `step-cli` if required (using the `step_cli` role)
 2. Install the CA root cert into the system trust store
 3. Configure the root user to automatically connect to your CA when running `step-cli`.
 
@@ -19,17 +19,14 @@ This role is intended to be run on regular hosts in your network that you want t
 
 ## Role Variables
 
-##### `step_cli_executable`
-- Path or name of the step-cli executable to use for executing commands in this role
-- Can be an absolute path or a command (make sure the executable is in $PATH) for all users
-- Default: `step-cli`
+### Install
 
-##### `step_cli_steppath`
-- Optionally set a custom `$STEPPATH` for bootstrapping.
-  All step configuration will be saved in this path instead of the default `$HOME/.step/`
-- **NOTE**: If set, you will have to supply your custom `$STEPPATH` in all future role/module/`step-cli` calls on this host that use the step config
-- Example: `/etc/step-cli`
-- Default: `$HOME/.step/`
+##### `step_cli_executable`
+- What to name and where to put the `step-cli` executable that will be installed by this role
+- Can be an absolute path (make sure that the parent directory is in $PATH) or a filename
+- If this executable is not found and `step_cli_executable` is a **path**, the executable will be installed there
+- If this executable is not found and  `step_cli_executable` is a **name**, the executable will be installed at `step_cli_install_dir` with the given name
+- Default: `step-cli`
 
 ##### `step_cli_version`
 - Set the version of step to install
@@ -38,7 +35,23 @@ This role is intended to be run on regular hosts in your network that you want t
   (e.g. if you are using the collection version 0.20.x you should be installing step-cli version 0.20.x as well)
 - Note that the role will query the GitHub API if this value is set to `latest`. Try setting
   a specific version if you are running into rate limiting issues
-- Default: `latest`
+- Default: `latest` (same as the upstream step-cli packages)
+
+##### `step_cli_install_dir`
+- Used if `step_cli_executable` is not found and contains a executable name
+- Sets the directory to install `step_cli_executable` into
+- The directory must already exist
+- Ignored if `step_cli_executable` contains a path already
+- Default: `/usr/bin`
+
+### Bootstrap
+
+##### `step_cli_steppath`
+- Optionally set a custom `$STEPPATH` for bootstrapping.
+  All step configuration will be saved in this path instead of the default `$HOME/.step/`
+- **NOTE**: If set, you will have to supply your custom `$STEPPATH` in all future role/module/`step-cli` calls on this host that use the step config
+- Example: `/etc/step-cli`
+- Default: `$HOME/.step/`
 
 ##### `step_bootstrap_ca_url`
 - URL of the `step-ca` CA
@@ -52,15 +65,18 @@ This role is intended to be run on regular hosts in your network that you want t
 
 ##### `step_bootstrap_install_cert`
 - Whether to install the CA cert into the system root trust store(s)
-- If set to false, this role only installs `step-cli` and configures the root user to run `step-cli` against your CA
+- If set to false, this role only installs `step-cli` and configures the root user to run `step-cli` against your CA.
+  Other applications on your system will **not** trust the CA, as the certificate won't be in the system trust store.
 - Default: Yes
 
 ##### `step_bootstrap_force`
 - Whether to force bootstrapping of the CA configuration.
-- If true, will cause an overwrite of any existing CA configuration, including root certificate.  Useful to change the CA URL, or even change to a new CA entirely.
+- If true, will cause an overwrite of any existing CA configuration, including root certificate. Useful to change the CA URL, or even change to a new CA entirely.
 - Default: No
 
 ## Example Playbook
+
+See the [step-cli role docs](/roles/step_cli/README.md) for more details on the install options
 
 ```
 - name: Configure the host to trust the CA and setup the step service user

--- a/roles/step_bootstrap_host/defaults/main.yml
+++ b/roles/step_bootstrap_host/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 step_cli_executable: step-cli
+step_cli_version: latest
+step_cli_install_dir: /usr/bin
 
 #step_bootstrap_ca_url:
 #step_bootstrap_fingerprint:

--- a/roles/step_bootstrap_host/molecule/default/converge.yml
+++ b/roles/step_bootstrap_host/molecule/default/converge.yml
@@ -10,3 +10,4 @@
         step_bootstrap_ca_url: https://step-ca.localdomain
         step_bootstrap_fingerprint: 345bf77397642dc9211a3820af0b1816c4afa430ad249ae705f1456b4bafa046
         step_cli_steppath: /etc/step-cli-molecule
+        step_cli_executable: /tmp/this-is-step-cli

--- a/roles/step_bootstrap_host/molecule/default/verify.yml
+++ b/roles/step_bootstrap_host/molecule/default/verify.yml
@@ -3,7 +3,7 @@
   hosts: clients
   tasks:
     - name: Verify that root is able to access ca
-      command: step-cli ca health
+      command: /tmp/this-is-step-cli ca health
       become: yes
       changed_when: no
       environment:

--- a/roles/step_bootstrap_host/tasks/main.yml
+++ b/roles/step_bootstrap_host/tasks/main.yml
@@ -29,7 +29,7 @@
   when: step_bootstrap_install_cert
 
 - name: Install CA cert into trust stores
-  ansible.builtin.command: "step-cli certificate install {{ step_cli_steppath }}/certs/root_ca.crt --all"
+  ansible.builtin.command: "{{ step_cli_executable }} certificate install {{ step_cli_steppath }}/certs/root_ca.crt --all"
   when:
     - step_bootstrap_install_cert
     - step_bootstrap_force or step_bootstrap_installed.rc != 0

--- a/roles/step_ca/README.md
+++ b/roles/step_ca/README.md
@@ -40,22 +40,43 @@ It is thus **very** important that you **back up your root key and password** in
 
 ## Role Variables
 
-### Installation
+### Installation (step-cli)
 
-##### `step_ca_version`
-- Set the version of step-ca to install
-- Can be a version tag (e.g. `0.15.3`), or `latest` to always install the most recent version
-- It is **highly** recommended that your ca version matches the collection version
-  (e.g. if you are using the collection version 0.20.x you should be installing step-ca version 0.20.x as well)
-- Note that the role will query the GitHub API if this value is set to `latest`. Try setting
-  a specific version if you are running into rate limiting issues
-- Default: `latest`
+##### `step_cli_executable`
+- What to name and where to put the `step-cli` executable that will be installed by this role
+- Can be an absolute path (make sure that the parent directory is in $PATH) or a filename
+- If this executable is not found and `step_cli_executable` is a **path**, the executable will be installed there
+- If this executable is not found and  `step_cli_executable` is a **name**, the executable will be installed at `step_cli_install_dir` with the given name
+- Default: `step-cli`
 
 ##### `step_cli_version`
 - Set the version of step to install
 - Can be a version tag (e.g. `0.15.3`), or `latest` to always install the most recent version
 - It is **highly** recommended that your cli version matches the collection version
   (e.g. if you are using the collection version 0.20.x you should be installing step-cli version 0.20.x as well)
+- Note that the role will query the GitHub API if this value is set to `latest`. Try setting
+  a specific version if you are running into rate limiting issues
+- Default: `latest` (same as the upstream step-cli packages)
+
+##### `step_cli_install_dir`
+- Used if `step_cli_executable` is not found and contains a executable name
+- Sets the directory to install `step_cli_executable` into
+- The directory must already exist
+- Ignored if `step_cli_executable` contains a path already
+- Default: `/usr/bin`
+
+### Installation (step-ca)
+
+##### `step_ca_executable`
+- Where to put the `step-ca` executable that will be installed by this role
+- Must be an absolute path
+- Default: `/usr/bin/step-ca`
+
+##### `step_ca_version`
+- Set the version of step-ca to install
+- Can be a version tag (e.g. `0.15.3`), or `latest` to always install the most recent version
+- It is **highly** recommended that your ca version matches the collection version
+  (e.g. if you are using the collection version 0.20.x you should be installing step-ca version 0.20.x as well)
 - Note that the role will query the GitHub API if this value is set to `latest`. Try setting
   a specific version if you are running into rate limiting issues
 - Default: `latest`
@@ -139,14 +160,6 @@ These variables need to be set as a group
 ##### `step_ca_ra_credentials_file`
 - The registration authority credentials file to use
 - Default: Not set
-
-
-### step-cli
-
-##### `step_cli_executable`
-- Path or name of the step-cli executable to use for executing commands in this role
-- Can be an absolute path or a command (make sure the executable is in $PATH) for all users
-- Default: `step-cli`
 
 
 ## Example Playbooks

--- a/roles/step_ca/defaults/main.yml
+++ b/roles/step_ca/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # Installation vars
+step_ca_executable: /usr/bin/step-ca
 step_ca_version: latest
 step_ca_user: step-ca
 step_ca_path: /etc/step-ca

--- a/roles/step_ca/vars/main.yml
+++ b/roles/step_ca/vars/main.yml
@@ -1,6 +1,4 @@
 ---
-step_ca_executable: /usr/bin/step-ca
-
 step_ca_root_password_file: "{{ step_ca_path }}/.password_root.txt"
 step_ca_intermediate_password_file: "{{ step_ca_path }}/.password.txt"
 

--- a/roles/step_cli/README.md
+++ b/roles/step_cli/README.md
@@ -1,6 +1,8 @@
 # maxhoesel.smallstep.step_cli
 
-Install the `step` CLI tool on a host
+Install the `step` CLI tool on a host.
+
+This role is used by `step_bootstrap_host` and `step_ca`, but can also be used standalone to install the cli tool and then do nothing else.
 
 ## Requirements
 
@@ -13,6 +15,13 @@ Install the `step` CLI tool on a host
 
 ## Role Variables
 
+##### `step_cli_executable`
+- What to name and where to put the `step-cli` executable that will be installed by this role
+- Can be an absolute path (make sure that the parent directory is in $PATH) or a filename
+- If this executable is not found and `step_cli_executable` is a **path**, the executable will be installed there
+- If this executable is not found and  `step_cli_executable` is a **name**, the executable will be installed at `step_cli_install_dir` with the given name
+- Default: `step-cli`
+
 ##### `step_cli_version`
 - Set the version of step to install
 - Can be a version tag (e.g. `0.15.3`), or `latest` to always install the most recent version
@@ -20,13 +29,34 @@ Install the `step` CLI tool on a host
   (e.g. if you are using the collection version 0.20.x you should be installing step-cli version 0.20.x as well)
 - Note that the role will query the GitHub API if this value is set to `latest`. Try setting
   a specific version if you are running into rate limiting issues
-- Default: `latest`
+- Default: `latest` (same as the upstream step-cli packages)
+
+##### `step_cli_install_dir`
+- Used if `step_cli_executable` is not found and contains a executable name
+- Sets the directory to install `step_cli_executable` into
+- The directory must already exist
+- Ignored if `step_cli_executable` contains a path already
+- Default: `/usr/bin`
 
 ## Example Playbook
 
-```
+```yaml
+# Install step-cli into the default path
 - hosts: all
   roles:
   - role: maxhoesel.smallstep.step_cli
     become: yes
+
+# Install a specific step-cli version to a custom path
+- hosts: all
+  roles:
+  - role: maxhoesel.smallstep.step_cli
+    become: yes
+    vars:
+      step_cli_version: "0.21.0"
+      # This will install step-cli to `/opt/step-cli`
+      # make sure that this directory is in $PATH, or the role will fail to find `step-cli`
+      # alternatively, you can also set `step_cli_executable` like so:
+      #step_cli_executable: /opt/step-cli
+      step_cli_install_dir: /opt
 ```

--- a/roles/step_cli/defaults/main.yml
+++ b/roles/step_cli/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
+step_cli_executable: step-cli
 step_cli_version: latest
+step_cli_install_dir: /usr/bin

--- a/roles/step_cli/molecule/default/converge.yml
+++ b/roles/step_cli/molecule/default/converge.yml
@@ -5,3 +5,5 @@
     - name: "Include step_cli"
       include_role:
         name: "step_cli"
+      vars:
+        step_cli_executable: /opt/step-cli

--- a/roles/step_cli/molecule/default/verify.yml
+++ b/roles/step_cli/molecule/default/verify.yml
@@ -4,5 +4,5 @@
   gather_facts: false
   tasks:
     - name: Verify that step-cli is installed
-      command: /usr/bin/step-cli version
+      command: /opt/step-cli version
       changed_when: no

--- a/roles/step_cli/tasks/install.yml
+++ b/roles/step_cli/tasks/install.yml
@@ -1,7 +1,12 @@
-- name: Look for existing step-cli binary
-  stat:
-    path: "{{ step_cli_executable }}"
-  register: step_cli_present
+- name: Look for step_cli_executable # noqa command-instead-of-shell
+  #"command" is a shell builtin, hence the need for the shell module
+  shell: "command -v {{ step_cli_executable }}"
+  register: step_cli_install
+  # dash (Debian sh shell) uses 127 instead of 1 for not found errors
+  failed_when: step_cli_install.rc not in [0,1,127]
+  changed_when: no
+  check_mode: no
+
 - name: Get currently installed step-cli version
   shell: >
     set -o pipefail &&
@@ -11,10 +16,14 @@
   changed_when: no
   check_mode: no
   register: step_cli_installed_version
-  when: step_cli_present.stat.exists
+  when: step_cli_install.rc == 0
 
 - name: Install step-cli
   block:
+    - name: Set step-cli install path
+      ansible.builtin.set_fact:
+        _step_cli_install_path: "{{ step_cli_install_dir }}/{{ step_cli_executable }}"
+      when: "'/' not in step_cli_executable"
     - name: Download and extract step-cli archive
       unarchive:
         src: "https://github.com/smallstep/cli/releases/download/v{{ step_cli_version }}/step_linux_{{ step_cli_version }}_{{ step_cli_arch[ansible_architecture] }}.tar.gz"
@@ -25,7 +34,7 @@
     - name: Install step-cli binary # noqa no-changed-when
       shell: >
         set -o pipefail &&
-        mv /tmp/step_{{ step_cli_version }}/bin/step {{ step_cli_executable }}
+        mv /tmp/step_{{ step_cli_version }}/bin/step {{ _step_cli_install_path | d(step_cli_executable) }}
       args:
         executable: /bin/bash
   always:

--- a/roles/step_cli/vars/main.yml
+++ b/roles/step_cli/vars/main.yml
@@ -1,8 +1,4 @@
 ---
-# Upstream uses /usr/bin instead of /usr/local/bin. Not a fan,
-# but we follow along for consistencies sake
-step_cli_executable: /usr/bin/step-cli
-
 step_cli_arch:
   x86_64: "amd64"
   aarch64: "arm64"


### PR DESCRIPTION
With this change, we now install step-cli/ca to the dir defined by the user.

This also fixes a potential issue where if a user specified a custom
executable via `step_bootstrap_host` that did not exist,
the role would have just installed step-cli to the default directory
instead of `step_cli_executable`.

From now on, we will determine the installation for step-cli path as follows:
- Use `step_cli_executable` if it is a path
- Use `step_cli_install_dir` + `step_cli_executable` if the latter is a filename

For step-ca, we simply require `step_ca_executable` to be an absolute path.
This is not possible for step-cli without breaking backwards compatibility as the variable
could also be a filename.