### PR TITLE
replace `except` with --password-file flags

### DIFF
--- a/roles/step_ca/README.md
+++ b/roles/step_ca/README.md
@@ -35,8 +35,6 @@ It is thus **very** important that you **back up your root key and password** in
   - A CentOS-compatible distribution like RockyLinux/AlmaLinux 8 or newer. RockyLinux is used for testing
 - Supported architectures: amd64, arm64
 - This role requires root access. Make sure to run this role with `become: yes` or equivalent
-- This role requires `expect` to answer some interactive prompts. It will automatically install
-  `expect` if it is not present
 
 ## Role Variables
 

--- a/roles/step_ca/tasks/init.yml
+++ b/roles/step_ca/tasks/init.yml
@@ -16,7 +16,7 @@
 
 - name: Initialize CA
   block:
-    - name: Create root and password file # noqa no-changed-when
+    - name: Create root cert password file # noqa no-changed-when
       copy:
         content: "{{ step_ca_root_password }}"
         dest: "{{ step_ca_root_password_file }}"
@@ -45,37 +45,16 @@
       become: yes
       become_user: "{{ step_ca_user }}"
 
-    - name: Change password for intermediate key # noqa no-changed-when
-      shell: |
-        set timeout 300
-        spawn {{ step_cli_executable }} crypto change-pass {{ step_ca_path }}/secrets/intermediate_ca_key -f
-        expect "Please enter the password to decrypt"
-        send -- "{{ step_ca_root_password }}\r"
-        expect "Please enter the password to encrypt"
-        send -- "{{ step_ca_intermediate_password }}\r"
-        expect
-      args:
-        executable: expect
+    - name: Change password for intermediate and ssh keys # noqa no-changed-when
+      command: "{{ step_cli_executable }} crypto change-pass {{ step_ca_path }}/secrets/{{ item }} -f --password-file={{ step_ca_root_password_file }} -new-password-file={{ step_ca_intermediate_password_file }}"
       become: yes
       become_user: "{{ step_ca_user }}"
-
-    - name: Change password for SSH keys
-      shell: |
-        set timeout 300
-        spawn {{ step_cli_executable }} crypto change-pass {{ step_ca_path }}/secrets/{{ item }} -f
-        expect "Please enter the password to decrypt"
-        send -- "{{ step_ca_root_password }}\r"
-        expect "Please enter the password to encrypt"
-        send -- "{{ step_ca_intermediate_password }}\r"
-        expect
-      args:
-        executable: expect
-      become: yes
-      become_user: "{{ step_ca_user }}"
-      loop:
-        - ssh_host_ca_key
-        - ssh_user_ca_key
-      when: step_ca_ssh
+      loop: "{{ _item_list | select | list }}"
+      vars:
+        _item_list:
+          - intermediate_ca_key
+          - "{{ step_ca_ssh | ternary('ssh_host_ca_key', '') }}"
+          - "{{ step_ca_ssh | ternary('ssh_user_ca_key', '') }}"
 
     - name: Remove initial provisioner
       maxhoesel.smallstep.step_ca_provisioner:

--- a/roles/step_ca/tasks/install.yml
+++ b/roles/step_ca/tasks/install.yml
@@ -1,8 +1,4 @@
 ---
-- name: Requirements are installed
-  package:
-    name: expect
-
 - name: Look for existing step-ca binary
   stat:
     path: "{{ step_ca_executable }}"


### PR DESCRIPTION
This change removes the need to shell out to `except`
when initializing the CA and setting up password files.
Newer versions of the step crypto change-pass command
include an option to pass the password via a file instead of interactive input.
As this removes the need for `except`, we should use that.