### PR TITLE
Roles: add Fedora 36 support

### DIFF
--- a/roles/step_acme_cert/README.md
+++ b/roles/step_acme_cert/README.md
@@ -10,6 +10,7 @@ before setting up a renewal service using `step-cli ca renew`s `--daemon` mode.
 - The following distributions are currently supported:
   - Ubuntu 18.04 LTS or newer
   - Debian 10 or newer
+  - Fedora 36 or newer
   - A CentOS-compatible distribution like RockyLinux/AlmaLinux 8 or newer. RockyLinux is used for testing
 - This role requires root access. Make sure to run this role with `become: yes` or equivalent
 - The host must be bootstrapped with `step_bootstrap_host` and the root user must be able to access the CA.

--- a/roles/step_acme_cert/molecule/default/molecule.yml
+++ b/roles/step_acme_cert/molecule/default/molecule.yml
@@ -126,6 +126,20 @@ platforms:
     networks:
       - name: smallstep_acme_cert
 
+  - name: step-cert-fedora-36
+    hostname: step-cert-fedora-36.localdomain
+    groups:
+      - clients
+      - fedora
+    image: "geerlingguy/docker-fedora36-ansible"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    override_command: false
+    pre_build_image: true
+    networks:
+      - name: smallstep_acme_cert
+
 provisioner:
   name: ansible
   config_options:

--- a/roles/step_acme_cert/molecule/default/prepare.yml
+++ b/roles/step_acme_cert/molecule/default/prepare.yml
@@ -4,7 +4,7 @@
       apt:
         update_cache: yes
 
-- hosts: rockylinux
+- hosts: rockylinux:fedora
   tasks:
     # Required to prevent issues with ansible_default_ipv4 missing
     - name: Install iproute

--- a/roles/step_bootstrap_host/README.md
+++ b/roles/step_bootstrap_host/README.md
@@ -13,6 +13,7 @@ It will:
 - The following distributions are currently supported:
   - Ubuntu 18.04 LTS or newer
   - Debian 10 or newer
+  - Fedora 36 or newer
   - A CentOS-compatible distribution like RockyLinux/AlmaLinux 8 or newer. RockyLinux is used for testing
 - This role requires root access. Make sure to run this role with `become: yes` or equivalent
 - `step-cli` will be automatically installed, if not already present

--- a/roles/step_bootstrap_host/molecule/default/molecule.yml
+++ b/roles/step_bootstrap_host/molecule/default/molecule.yml
@@ -126,6 +126,20 @@ platforms:
     networks:
       - name: smallstep_bootstrap_host
 
+  - name: step-host-fedora-36
+    hostname: step-host-fedora-36.localdomain
+    groups:
+      - clients
+      - fedora
+    image: "geerlingguy/docker-fedora36-ansible"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    override_command: false
+    pre_build_image: true
+    networks:
+      - name: smallstep_bootstrap_host
+
 provisioner:
   name: ansible
   config_options:

--- a/roles/step_bootstrap_host/molecule/default/prepare.yml
+++ b/roles/step_bootstrap_host/molecule/default/prepare.yml
@@ -4,7 +4,7 @@
       apt:
         update_cache: yes
 
-- hosts: rockylinux
+- hosts: rockylinux:fedora
   tasks:
     # Required to prevent issues with ansible_default_ipv4 missing
     - name: Install iproute

--- a/roles/step_ca/README.md
+++ b/roles/step_ca/README.md
@@ -43,7 +43,7 @@ It is thus **very** important that you **back up your root key and password** in
 
 ##### `step_cli_executable`
 - What to name and where to put the `step-cli` executable that will be installed by this role
-- Can be an absolute path (make sure that the parent directory is in $PATH) or a filename
+- Can be an absolute path (make sure that the parent directory is in $PATH and has correct SELinux policies set, if applicable) or a filename
 - If this executable is not found and `step_cli_executable` is a **path**, the executable will be installed there
 - If this executable is not found and  `step_cli_executable` is a **name**, the executable will be installed at `step_cli_install_dir` with the given name
 - Default: `step-cli`

--- a/roles/step_ca/README.md
+++ b/roles/step_ca/README.md
@@ -32,6 +32,7 @@ It is thus **very** important that you **back up your root key and password** in
 - The following distributions are currently supported:
   - Ubuntu 18.04 LTS or newer
   - Debian 10 or newer
+  - Fedora 36 or newer
   - A CentOS-compatible distribution like RockyLinux/AlmaLinux 8 or newer. RockyLinux is used for testing
 - Supported architectures: amd64, arm64
 - This role requires root access. Make sure to run this role with `become: yes` or equivalent

--- a/roles/step_ca/molecule/default/molecule.yml
+++ b/roles/step_ca/molecule/default/molecule.yml
@@ -87,6 +87,17 @@ platforms:
     override_command: false
     pre_build_image: true
 
+  - name: step-ca-fedora-36
+    groups:
+      - fedora
+      - ca
+    image: "geerlingguy/docker-fedora36-ansible"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    override_command: false
+    pre_build_image: true
+
 provisioner:
   name: ansible
   config_options:

--- a/roles/step_ca/molecule/default/prepare.yml
+++ b/roles/step_ca/molecule/default/prepare.yml
@@ -4,7 +4,7 @@
       apt:
         update_cache: yes
 
-- hosts: rockylinux
+- hosts: rockylinux:fedora
   tasks:
     # Required to prevent issues with ansible_default_ipv4 missing
     - name: Install iproute

--- a/roles/step_ca/tasks/install.yml
+++ b/roles/step_ca/tasks/install.yml
@@ -26,7 +26,7 @@
     - name: Install step-ca binary # noqa no-changed-when
       shell: >
         set -o pipefail &&
-        mv /tmp/step-ca_{{ step_ca_version }}/bin/* {{ step_ca_executable | dirname }}
+        mv -Z /tmp/step-ca_{{ step_ca_version }}/bin/* {{ step_ca_executable | dirname }}
       args:
         executable: /bin/bash
       notify: restart step-ca

--- a/roles/step_cli/README.md
+++ b/roles/step_cli/README.md
@@ -9,6 +9,7 @@ This role is used by `step_bootstrap_host` and `step_ca`, but can also be used s
 - The following distributions are currently supported:
   - Ubuntu 18.04 LTS or newer
   - Debian 10 or newer
+  - Fedora 36 or newer
   - A CentOS-compatible distribution like RockyLinux/AlmaLinux 8 or newer. RockyLinux is used for testing
 - Supported architectures: amd64, arm64
 - This role requires root access. Make sure to run this role with `become: yes` or equivalent

--- a/roles/step_cli/README.md
+++ b/roles/step_cli/README.md
@@ -18,7 +18,7 @@ This role is used by `step_bootstrap_host` and `step_ca`, but can also be used s
 
 ##### `step_cli_executable`
 - What to name and where to put the `step-cli` executable that will be installed by this role
-- Can be an absolute path (make sure that the parent directory is in $PATH) or a filename
+- Can be an absolute path (make sure that the parent directory is in $PATH and has correct SELinux policies set, if applicable) or a filename
 - If this executable is not found and `step_cli_executable` is a **path**, the executable will be installed there
 - If this executable is not found and  `step_cli_executable` is a **name**, the executable will be installed at `step_cli_install_dir` with the given name
 - Default: `step-cli`

--- a/roles/step_cli/molecule/default/molecule.yml
+++ b/roles/step_cli/molecule/default/molecule.yml
@@ -81,6 +81,16 @@ platforms:
     override_command: false
     pre_build_image: true
 
+  - name: step-cli-fedora-36
+    image: "geerlingguy/docker-fedora36-ansible"
+    groups:
+      - fedora
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    override_command: false
+    pre_build_image: true
+
 provisioner:
   name: ansible
   config_options:

--- a/roles/step_cli/molecule/default/prepare.yml
+++ b/roles/step_cli/molecule/default/prepare.yml
@@ -4,7 +4,7 @@
       apt:
         update_cache: yes
 
-- hosts: rockylinux
+- hosts: rockylinux:fedora
   tasks:
     # Required to prevent issues with ansible_default_ipv4 missing
     - name: Install iproute

--- a/roles/step_cli/tasks/install.yml
+++ b/roles/step_cli/tasks/install.yml
@@ -34,9 +34,13 @@
     - name: Install step-cli binary # noqa no-changed-when
       shell: >
         set -o pipefail &&
-        mv /tmp/step_{{ step_cli_version }}/bin/step {{ _step_cli_install_path | d(step_cli_executable) }}
+        mv -Z /tmp/step_{{ step_cli_version }}/bin/step {{ _step_cli_install_path | d(step_cli_executable) }}
       args:
         executable: /bin/bash
+    # mv does not automatically set selinux labels, so we have to do it ourselves
+    - name: Restore SELinux context for binary
+      command: "restorecon -v {{ _step_cli_install_path }}"
+      when: ansible_selinux is defined and ansible_selinux and ansible_selinux.status == 'enabled'
   always:
     - name: Remove step release archive
       file:


### PR DESCRIPTION
This change adds official support for Fedora 36 to all the roles contained in this collection.

This should also fix #177 