### PR TITLE
Fixed missing check for existing root files

### DIFF
--- a/roles/step_ca/tasks/init.yml
+++ b/roles/step_ca/tasks/init.yml
@@ -82,8 +82,8 @@
         --provisioner-password-file={{ step_ca_root_password_file | quote }}
         {% if step_ca_url is defined %} --with-ca-url={{ step_ca_url | quote }}{% endif %}
         {% if step_ca_ssh %} --ssh{% endif %}
-        {% if step_ca_existing_root_file %} --root={{ step_ca_existing_root_file | quote }}{% endif %}
-        {% if step_ca_existing_key_file %} --key={{ step_ca_existing_key_file | quote }}{% endif %}
+        {% if step_ca_existing_root_file is defined %} --root={{ step_ca_existing_root_file | quote }}{% endif %}
+        {% if step_ca_existing_key_file is defined %} --key={{ step_ca_existing_key_file | quote }}{% endif %}
         {% if step_ca_ra is defined %} --ra={{ step_ca_ra | quote }}{% endif %}
         {% if step_ca_ra_issuer is defined %} --issuer={{ step_ca_ra_issuer | quote }}{% endif %}
         {% if step_ca_ra_credentials_file is defined %} --credentials-file={{ step_ca_ra_credentials_file | quote }}{% endif %}


### PR DESCRIPTION
## Error

When following the instructions for [setting up a step ca installation](https://github.com/maxhoesel-ansible/ansible-collection-smallstep#create-a-ca) the CA role will bug out due to the variables for previous root files not being there.

```
TASK [maxhoesel.smallstep.step_ca : Initialize CA] ***************************************************************************************************************************
Mittwoch 07 September 2022  21:39:24 +0200 (0:00:00.022)       0:00:40.066 **** 
fatal: [ca]: FAILED! => 
  msg: |-
    The task includes an option with an undefined variable. The error was: 'step_ca_existing_root_file' is undefined
  
    The error appears to be in '/home/danielsreichenbach/Projects/kogito/infrastructure/ansible/maasstar/collections/ansible_collections/maxhoesel/smallstep/roles/step_ca/tasks/init.yml': line 74, column 7, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
          when: step_ca_existing_key_password is defined
        - name: Initialize CA # noqa no-changed-when
          ^ here
```

## The fix

With adding `is defined` checks initial provisioning will pass, and allow to run with and without previous files.