### PR TITLE
Sync collection with upstream version 0.23

### DIFF
--- a/roles/step_ca/tasks/install.yml
+++ b/roles/step_ca/tasks/install.yml
@@ -23,13 +23,22 @@
         remote_src: yes
       retries: 3
       delay: 3
-    - name: Install step-ca binary # noqa no-changed-when
+    - name: Install step-ca binary <0.23 # noqa no-changed-when
       shell: >
         set -o pipefail &&
         mv -Z /tmp/step-ca_{{ step_ca_version }}/bin/* {{ step_ca_executable | dirname }}
       args:
         executable: /bin/bash
       notify: restart step-ca
+      when: step_ca_version is version("0.23", "<")
+    - name: Install step-ca binary >=0.23 # noqa no-changed-when
+      shell: >
+        set -o pipefail &&
+        mv -Z /tmp/step-ca_{{ step_ca_version }}/step-ca {{ step_ca_executable | dirname }}
+      args:
+        executable: /bin/bash
+      notify: restart step-ca
+      when: step_ca_version is version("0.23", ">=")
   always:
     - name: Remove step release archive
       file:

--- a/tests/constants.sh
+++ b/tests/constants.sh
@@ -4,5 +4,5 @@
 export PYTHON_VERSION=3.6
 
 # step tools versions used for all tests
-export STEP_CA_VERSION=0.22.0
-export STEP_CLI_VERSION=0.22.0
+export STEP_CA_VERSION=0.23.0
+export STEP_CLI_VERSION=0.23.0


### PR DESCRIPTION
This change bumps the supported step version to 0.23, neccessitating  a new release of this collection