### PR TITLE
Switch to podman for testing collection roles/modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ celerybeat.pid
 # Environments
 .env
 .venv*
+venv*/
 env/
 venv/
 ENV/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,10 @@ Below you will find the information needed to contribute to this project.
 
 Note that by contributing to this collection, you agree with the code of conduct you can find [here.](/CODE_OF_CONDUCT.md)
 
-## Requirements
+# Getting Started
 
 To begin development on this collection, you need to have the following dependencies installed:
 
-- Docker, accessible by your local user account
 - Python 3.8 or newer (for running ansible-core 2.13+)
 
 ## Quick Start
@@ -17,13 +16,11 @@ To begin development on this collection, you need to have the following dependen
 2. Run `./scripts/setup.sh` to configure a local dev environment (virtualenv) with all required dependencies
 3. Activate the virtualenv with `source .venv/bin/activate`
 4. Make your changes and commit them to a new branch
-5. Run the tests locally with `./scripts/test.sh`. This will run the full test suite that also runs in the CI
+5. Run the tests locally by running `./tests/test-<target>`. See below for more details on these testing scripts
 6. Once you're done, commit your changes (make sure that you are in the venv).
    Pre-commit will format your code and check for any obvious errors when you do so.
 
-## Development Guide
-
-### Module Development
+# Developing Modules
 
 The modules in this collection are mostly simple wrappers around the `step-cli` tool.
 Feel free to add a new module if you would like to implement another subcommand.
@@ -35,37 +32,244 @@ Here are some general hints for module development:
 - Use the `CLIWrapper` class in [step_cli_wrapper.py](/plugins/module_utils/step_cli_wrapper.py) to run step-cli commands
 - Try to make the calls idempotent where possible. Modules should always support check mode
 
-You need to write tests to ensure that your module works and keeps working properly (see [here](https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html) for the Ansible Integration testing guide). Notes:
+# Developing Roles
 
-- Typically, each module should have one integration test target (see [here for examples](/tests/integration/targets/)) that ensures that the module works as expected
-- If your module interacts with a remote step CA (i.e. your module is part of the `step ca` subcommand), you can request creating one by adding the following to your targets `meta/main.yml`:
+Each role in this collection performs a complex task to bring a remote host into a desired state.
+If you want to write a new role, look to the existing ones for inspiration.
 
-    ```yaml
-    # In targets/<your_target>/meta/main.yml
+Some general guidelines:
 
-    ---
-    dependencies:
-    - setup_remote_ca
-    ```
+- Try to support most common Linux distributions (including Ubuntu, Debian, Fedora and Rockylinux)
+- Keep the configuration for the user simple and try to provide sensible defaults where possible
+- Try to avoid using complex data structures as role variables/parameters, use simple values that can be composed easily instead.
 
-    This will automatically configure your host to trust the remote CA. Then, use the variable names defined in `tests/integration/integration_config.yml.template` to access the remote CA. Use an existing target for guidance if needed.
-- All targets are run sequentially on the same host. Make sure to clean up after yourself! You don't need to handle failures gracefully however,
-  as the testing environment is destroyed on the first error.
-- You can test your modules by running `tests/test-modules-sanity` and `tests/test-modules-integration`. These tests are also run as part of the CI.
+# Testing Infrastructure
 
-### Role Development
+Writing tests for your contributions ensure that they continue working in the future.
+In addition to the testing venv, you will also need the following:
 
-General Notes:
+- `podman` 4 or newer for role tests with molecule (see [here](#setting-up-podman)).
+- `docker` for module tests (both sanity and integration). `podman-docker` may also function, but this is not guaranteed.
 
-- None so far
+We use `tox` in conjunction with `tox-ansible` to run tests against both modules and roles with multiple Ansible versions.
+If you set up your environment as described [above](#quick-start), you should already have everything installed.
 
-For testing, we use the `molecule` framework. Molecule scenarios are handled by `tox` and the [`tox-ansible` extension]( https://github.com/ansible-community/tox-ansible). Notes:
+To run tests, use the wrapper scripts in the `tests` directory from the collection root:
 
-- To see all available scenarios, run `tox -l` and look for the scenarios starting with `ansible-py*`.
-- To run all molecule scenarios, simply call `tests/test-roles`
-    - Or pass a (partial) scenario name as a filter to limit execution (for example, `/tests/test-roles acme_cert` to limit molecule scenarios to the ACME role only)
+- [`./tests/test-modules`](./tests/test-modules) will run ansible-test against the modules in the collection and verify them
+    - [`test-modules-sanity`](./tests/test-modules-sanity) performs basic syntax and validation checks
+    - [`test-modules-integration`]((./tests/test-modules-integration)) runs the module integration [test targets](./tests/integration/targets/).
+- [`./tests/test-roles`](./tests/test-roles) will use `molecule` to run tests on all roles in the collection (this might take a long time!)
+    - To limit the scope to a single role, add a filter parameter: `./tests/test-roles step_cli`
+    - Alternatively, you can use `tox -l` to list all available scenarios and then select a single one with `tox -e <scenario-name-here>`
 
-## Information for maintainers
+## Module Tests
+
+All module tests are executed using `docker`, make sure that it is installed, running and that you are in the `docker` group.
+
+The sanity tests should "just work" - they can give you valuable feedback and uncover accidental mistakes like mismatches between your module docs and argspec.
+
+You can run the integration tests with the provided script.
+
+### Writing Module tests
+
+When writing module tests, you can start out by either copying an existing target such as [`step_ca_bootstrap`](./tests/integration/targets/step_ca_bootstrap/), or start out from scratch.
+In either case, there is a step-ca available in the integration environment that you can use for your tests ([`test-modules-integration`](./tests/test-modules-integration) takes care of that, see [this section](#using-the-local-ca) for mode details on how this works).
+
+To access it, your target structure must look like this:
+
+```
+meta/
+  main.yml
+tasks/
+  main.yml
+```
+```yaml
+# in meta/main.yml:
+# Configure the local target to connect to the remote CA
+dependencies:
+  - setup_remote_ca
+
+# in tasks/main.yml:
+- name: Get a certificate from the CA
+  maxhoesel.smallstep.step_ca_certificate:
+    # your tests go here
+```
+
+See the [integration config template](./tests/integration/integration_config.yml.template) for a list of variables that you can use in your integration targets.
+
+#### Using the Local CA
+
+The CA is normally a separate docker container managed by the [`test-modules-integration`](./tests/test-modules-integration) script.
+This works fine for most modules.
+However, there are a few modules (such as [`step_ca_provisioner`](./plugins/modules/step_ca_provisioner.py)) that need to run on the same host that the CA is on.
+If you are writing such a module, you can use a local CA by modifying your target like so:
+
+```yaml
+# in meta/main.yml
+dependencies:
+  - setup_local_ca
+
+# in tasks/main.yml
+- block:
+    - name: Perform a test here
+      maxhoesel.smallstep.step_ca_module:
+        #
+  tags:
+    - local-ca
+```
+
+This will cause the target to get run on a host with a local CA installed, see the [integration config template](./tests/integration/integration_config.yml.template) for available values to access said CA.
+
+In the background, this is done by running the `local-ca` integration tests on a custom test host based on the official `step-ca` docker image, see [here](./tests/integration/docker/step-ca-ansible/README.md) for details.
+
+
+## Role Tests
+
+Testing Ansible roles ensures that they do exactly what we want them to and nothing more.
+We perform role tests using `molecule` with the `molecule-podman` driver with rootless containers.
+
+---
+
+Why not just `molecule-docker`? Simple: This collection needs systemd inside its test containers to start the `ca` server among other things, and modern versions of [systemd do not work inside docker containers anymore](https://github.com/ansible-community/molecule/discussions/3108).
+Meanwhile, `podman` has official support for passing through the host systemd and with the 4.0 release, podman networking is now mature enough that we can use it in our role tests. In addition, `podman` offers daemonless, rootless containers, which improves security considerably.
+
+---
+
+Before you run any tests, make sure you follow the instructions in [the following section](#setting-up-podman).
+
+Once you're done, you can:
+
+- See all available scenarios with `tox -l` and look for the scenarios starting with `ansible-py*`.
+- Run all molecule scenarios with `tests/test-roles`
+- Pass a (partial) scenario name as a filter to limit execution (for example, `/tests/test-roles acme_cert` to limit molecule scenarios to the ACME role only)
+
+
+### Setting up Podman
+
+To run role tests, you will need the following:
+
+- `podman` version 4+ (as it comes with the new netvark networking stack)
+- `aardvark-dns`
+
+On Archlinux, you can install these with this command: `sudo pacman -S podman aardvark-dns`.
+Other distributions may not have this version available in their repositories, you might have install things manually.
+
+**NOTE:** If you previously used an older version of `podman` you will have to migrate to the new networking stack. This can be done with `podman system reset`
+
+Finally, make sure that your user as a subuid/subgid configuration associated with them so that we can run rootless containers.
+Check the `/etc/subuid` and `/etc/subgid` files for entries corresponding to your username.
+If none are found, you can add them like so: `sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 <USERNAME>` (make sure that the range is not  already taken in `/etc/subuid`/`/etc/subgid`).
+
+Once you have applied your changes, run `podman system migrate` to force `podman` to pick up the new configuration.
+
+That's it! Podman should now be working! To test it, you can run a container just like with docker: `podman run --rm -it ubuntu bash`
+
+### Writing Role Tests
+
+There are tons of good guides online for how to write tests using molecule.
+Alternatively, you can always look at the existing molecule scenarios in this collection
+
+When creating a new molecule scenario, your directory structure should look like this:
+
+```
+some_role/
+  defaults/
+  meta/
+  molecule/
+    default/
+      converge.yml
+      molecule.yml
+      prepare.yml
+      requirements.txt # --> symlink to /requirements-molecule.txt
+      verify.yml
+    another-scenario/
+      ...
+  tasks
+  ...
+```
+
+The `requirements.txt` symlink is used by `tox-ansible` when running tests via `tox` to install a specific, known-good version of `molecule` and the `molecule-podman` driver.
+
+Below is a shortened example `molecule.yml` that you can include in your own scenarios:
+
+```yaml
+---
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+  # Example for a systemd-enabled test container
+  - name: step-cli-ubuntu-22
+    # We use the images provided by geerlingguy where possible, as they provide out-of-the-box
+    # support for Ansible (pre_build_image=true, speeds up testing).
+    image: "docker.io/geerlingguy/docker-ubuntu2204-ansible"
+    # Grouping your hosts makes it easier to address them in your playbooks
+    groups:
+      - ubuntu
+    # By default, molecule overrides the container start command with a while-true loop.
+    # Instead, we want systemd to be the init command, which is already the case for geerlingguy images
+    override_command: false
+    # When false, this causes molecule to modify the container so that ansible can connect to it.
+    # This is not needed for geerlingguy containers
+    pre_build_image: true
+    # Force podman systemd integration. By default, podmans systemd detection only uses a few specific paths,
+    # which might get not detected on some distros
+    systemd: always
+    # Assign the container to a non-default network. This is required when you want inter-container communication.
+    network: molecule-ste-ca
+
+#... more platforms here
+
+  # You might need a running CA for some of your role tests.
+  # Instead of creating your own, you can just use the official step-ca docker image and link your test containers to it.
+  # See the provisioner section for how the containers can access the CA
+  - name: step-ca
+    groups:
+      - ca
+    image: "docker.io/smallstep/step-ca:${STEP_CA_VERSION:-latest}"
+    # we don't actually use the container with ansible, leave it as is
+    override_command: false
+    pre_build_image: true
+    env:
+      DOCKER_STEPCA_INIT_NAME: "Molecule_Bootstrap_CA"
+      DOCKER_STEPCA_INIT_DNS_NAMES: "step-ca,localhost"
+    network: molecule-step-ca
+provisioner:
+  name: ansible
+  env:
+    # This is required for podman to function: https://github.com/ansible-community/molecule-podman/issues/2
+    ANSIBLE_PIPELINING: false
+    #ANSIBLE_VERBOSITY: 3 # enable for debugging
+  inventory:
+    group_vars:
+      all:
+        # These will be set to a concrete version if running from tox,
+        # fallback on the latest version if running molecule directly
+        step_cli_version: ${STEP_CLI_VERSION:-latest}
+        step_ca_version: ${STEP_CA_VERSION:-latest}
+        # Tell the test containers where to find the CA
+        step_bootstrap_ca_url: https://step-ca:9000
+scenario:
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - check # also run check mode in regular tests
+    - side_effect
+    - verify
+    - destroy
+verifier:
+  name: ansible
+```
+
+# Misc Lifecycle Maintainer Information
 
 - To update the smallstep cli/ca versions that are used to run the tests, bump the values in `tests/constants.sh`
 - This project uses sematic versioning. Version numbers and  releases/changelogs are automatically generated using [release-drafter](https://github.com/release-drafter/release-drafter), utilizing pull request labels.

--- a/requirements-molecule.txt
+++ b/requirements-molecule.txt
@@ -2,4 +2,4 @@
 # Molecule and molecule-docker are ... not the most reliable pieces of software when it comes to updates,
 # so lets manage their versions ourselves
 molecule==4.0.3
-molecule-docker==2.1.0
+molecule-podman==2.0.3

--- a/roles/step_acme_cert/molecule/default/molecule.yml
+++ b/roles/step_acme_cert/molecule/default/molecule.yml
@@ -1,165 +1,108 @@
----
-dependency:
-  name: galaxy
 driver:
-  name: docker
+  name: podman
 platforms:
-  # Note on containers:
-  # - We use the images provided by geerlingguy, as they provide out-of-the-box
-  #   support for Ansible and systemd (needed to test service management).
-  # - The containers run as privileged containers so that we can
-  #   use systemd functionality. This *should* be possible with unpriliged
-  #   containers as well, but is quite the headache.
-  # - they are connected to a shared network to allow simulating a remote CA
+  # We use the images provided by geerlingguy where possible, as they provide out-of-the-box
+  # support for Ansible (pre_build_image=true, speeds up testing).
 
   # Use the smallstep-provided CA image for testing
   - name: step-ca
-    hostname: ${STEP_MOLECULE_CA_HOSTNAME:-step-ca-molecule.localdomain}
     groups:
       - ca
-    image: "smallstep/step-ca:${STEP_CA_VERSION:-latest}"
+    image: "docker.io/smallstep/step-ca:${STEP_CA_VERSION:-latest}"
+    # we don't actually use the container with ansible, leave it as is
     override_command: false
-    pre_build_image: true # we don't actually use the container with ansible, leave it as is
+    pre_build_image: true
     env:
-      DOCKER_STEPCA_INIT_NAME: Molecule ACME CA
-      DOCKER_STEPCA_INIT_DNS_NAMES: "${STEP_MOLECULE_CA_HOSTNAME:-step-ca-molecule.localdomain},localhost"
-    docker_networks:
-      - name: smallstep_acme_cert
-    networks:
-      - name: smallstep_acme_cert
+      DOCKER_STEPCA_INIT_NAME: "Molecule_Bootstrap_CA"
+      DOCKER_STEPCA_INIT_DNS_NAMES: "step-ca,localhost"
+    network: molecule-step-acme-cert
 
-  - name: step-cert-ubuntu-22
-    hostname: step-cert-ubuntu-22.localdomain
+  - name: step-host-ubuntu-22
     groups:
       - clients
       - ubuntu
-    image: "geerlingguy/docker-ubuntu2204-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-ubuntu2204-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_acme_cert
-    networks:
-      - name: smallstep_acme_cert
+    network: molecule-step-acme-cert
 
-  - name: step-cert-ubuntu-20
-    hostname: step-cert-ubuntu-20.localdomain
+  - name: step-host-ubuntu-20
     groups:
       - clients
       - ubuntu
-    image: "geerlingguy/docker-ubuntu2004-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_acme_cert
-    networks:
-      - name: smallstep_acme_cert
+    network: molecule-step-acme-cert
 
-  - name: step-cert-ubuntu-18
-    hostname: step-cert-ubuntu-18.localdomain
+  - name: step-host-ubuntu-18
     groups:
       - clients
       - ubuntu
-    image: "geerlingguy/docker-ubuntu1804-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-ubuntu1804-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_acme_cert
-    networks:
-      - name: smallstep_acme_cert
+    network: molecule-step-acme-cert
 
-  - name: step-cert-debian-11
-    hostname: step-cert-debian-11.localdomain
+  - name: step-host-debian-11
     groups:
       - clients
       - debian
-    image: "geerlingguy/docker-debian11-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-debian11-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_acme_cert
-    networks:
-      - name: smallstep_acme_cert
+    network: molecule-step-acme-cert
 
-  - name: step-cert-debian-10
-    hostname: step-cert-debian-10.localdomain
+  - name: step-host-debian-10
     groups:
       - clients
       - debian
-    image: "geerlingguy/docker-debian10-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-debian10-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_acme_cert
-    networks:
-      - name: smallstep_acme_cert
+    network: molecule-step-acme-cert
 
-  - name: step-cert-rockylinux-9
-    hostname: step-cert-rockylinux-9.localdomain
+  - name: step-host-rockylinux-9
     groups:
       - clients
       - rockylinux
-    image: "geerlingguy/docker-rockylinux9-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-rockylinux9-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_acme_cert
-    networks:
-      - name: smallstep_acme_cert
+    network: molecule-step-acme-cert
 
-  - name: step-cert-rockylinux-8
-    hostname: step-cert-rockylinux-8.localdomain
+  - name: step-host-rockylinux-8
     groups:
       - clients
       - rockylinux
-    image: "geerlingguy/docker-rockylinux8-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-rockylinux8-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_acme_cert
-    networks:
-      - name: smallstep_acme_cert
+    network: molecule-step-acme-cert
 
-  - name: step-cert-fedora-36
-    hostname: step-cert-fedora-36.localdomain
+  - name: step-host-fedora-36
     groups:
       - clients
       - fedora
-    image: "geerlingguy/docker-fedora36-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-fedora36-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_acme_cert
-    networks:
-      - name: smallstep_acme_cert
+    network: molecule-step-acme-cert
 
 provisioner:
   name: ansible
   env:
-    ANSIBLE_PIPELINING: "True"
+    # This is required for podman to function: https://github.com/ansible-community/molecule-podman/issues/2
+    ANSIBLE_PIPELINING: false
+    #ANSIBLE_VERBOSITY: 3 # enable for debugging
   inventory:
     group_vars:
       ca:
@@ -169,9 +112,8 @@ provisioner:
         step_ca_version: ${STEP_CA_VERSION:-latest}
         step_cli_steppath: /etc/step-cli-molecule
 
-        step_bootstrap_ca_url: https://${STEP_MOLECULE_CA_HOSTNAME:-step-ca-molecule.localdomain}:9000
-
         step_acme_cert_ca_provisioner: ACME
+        step_bootstrap_ca_url: https://step-ca:9000
 
 scenario:
   test_sequence:

--- a/roles/step_acme_cert/molecule/default/prepare.yml
+++ b/roles/step_acme_cert/molecule/default/prepare.yml
@@ -15,18 +15,18 @@
   tasks:
     # Somewhat hacky way to customize the container image, but we make do with what we have
     - name: Add ACME provisioner # noqa no-changed-when
-      ansible.builtin.command: "docker exec step-ca step ca provisioner add {{ step_acme_cert_ca_provisioner }} --type=ACME"
+      ansible.builtin.command: "podman exec step-ca step ca provisioner add {{ step_acme_cert_ca_provisioner }} --type=ACME"
     - name: Get CA PID
-      ansible.builtin.command: docker exec step-ca pgrep -f step-ca
+      ansible.builtin.command: podman exec step-ca pgrep -f step-ca
       register: _step_ca_pid
       changed_when: false
     - name: Reload step-ca # noqa no-changed-when
-      ansible.builtin.command: "docker exec step-ca kill -1 {{ _step_ca_pid.stdout }}"
+      ansible.builtin.command: "podman exec step-ca kill -1 {{ _step_ca_pid.stdout }}"
 
 - hosts: clients
   tasks:
     - name: Get CA fingerprint
-      ansible.builtin.command: docker exec step-ca step certificate fingerprint certs/root_ca.crt
+      ansible.builtin.command: podman exec step-ca step certificate fingerprint certs/root_ca.crt
       register: _ca_fingerprint
       changed_when: false
       check_mode: false
@@ -41,6 +41,7 @@
         name: nginx
         state: stopped
         enabled: no
+
     - name: Bootstrap host
       include_role:
         name: maxhoesel.smallstep.step_bootstrap_host

--- a/roles/step_bootstrap_host/molecule/default/converge.yml
+++ b/roles/step_bootstrap_host/molecule/default/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     # Slightly hacky way to get the CA fingerprint. We could also look at logs but i prefer this method
     - name: Get CA fingerprint
-      command: docker exec step-ca step certificate fingerprint certs/root_ca.crt
+      ansible.builtin.command: podman exec step-ca step certificate fingerprint certs/root_ca.crt
       register: _ca_fingerprint
       changed_when: false
       check_mode: false

--- a/roles/step_bootstrap_host/molecule/default/molecule.yml
+++ b/roles/step_bootstrap_host/molecule/default/molecule.yml
@@ -2,164 +2,110 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
+  name: podman
 platforms:
-  # Note on containers:
-  # - We use the images provided by geerlingguy, as they provide out-of-the-box
-  #   support for Ansible and systemd (needed to test service management).
-  # - The containers run as privileged containers so that we can
-  #   use systemd functionality. This *should* be possible with unpriliged
-  #   containers as well, but is quite the headache.
-  # - they are connected to a shared network to allow simulating a remote CA
+  # We use the images provided by geerlingguy where possible, as they provide out-of-the-box
+  # support for Ansible (pre_build_image=true, speeds up testing).
 
   # Use the smallstep-provided CA image for testing
   - name: step-ca
-    hostname: ${STEP_MOLECULE_CA_HOSTNAME:-step-ca-molecule.localdomain}
     groups:
       - ca
-    image: "smallstep/step-ca:${STEP_CA_VERSION:-latest}"
+    image: "docker.io/smallstep/step-ca:${STEP_CA_VERSION:-latest}"
+    # we don't actually use the container with ansible, leave it as is
     override_command: false
-    pre_build_image: true # we don't actually use the container with ansible, leave it as is
+    pre_build_image: true
     env:
-      DOCKER_STEPCA_INIT_NAME: Molecule Bootstrap CA
-      DOCKER_STEPCA_INIT_DNS_NAMES: "${STEP_MOLECULE_CA_HOSTNAME:-step-ca-molecule.localdomain},localhost"
-    docker_networks:
-      - name: smallstep_bootstrap_host
-    networks:
-      - name: smallstep_bootstrap_host
+      DOCKER_STEPCA_INIT_NAME: "Molecule_Bootstrap_CA"
+      DOCKER_STEPCA_INIT_DNS_NAMES: "step-ca,localhost"
+    network: molecule-step-bootstrap-host
 
   - name: step-host-ubuntu-22
-    hostname: step-host-ubuntu-22.localdomain
     groups:
       - clients
       - ubuntu
-    image: "geerlingguy/docker-ubuntu2204-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-ubuntu2204-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_bootstrap_host
-    networks:
-      - name: smallstep_bootstrap_host
+    network: molecule-step-bootstrap-host
 
   - name: step-host-ubuntu-20
-    hostname: step-host-ubuntu-20.localdomain
     groups:
       - clients
       - ubuntu
-    image: "geerlingguy/docker-ubuntu2004-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_bootstrap_host
-    networks:
-      - name: smallstep_bootstrap_host
+    network: molecule-step-bootstrap-host
 
   - name: step-host-ubuntu-18
-    hostname: step-host-ubuntu-18.localdomain
     groups:
       - clients
       - ubuntu
-    image: "geerlingguy/docker-ubuntu1804-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-ubuntu1804-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_bootstrap_host
-    networks:
-      - name: smallstep_bootstrap_host
+    network: molecule-step-bootstrap-host
 
   - name: step-host-debian-11
-    hostname: step-host-debian-11.localdomain
     groups:
       - clients
       - debian
-    image: "geerlingguy/docker-debian11-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-debian11-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_bootstrap_host
-    networks:
-      - name: smallstep_bootstrap_host
+    network: molecule-step-bootstrap-host
 
   - name: step-host-debian-10
-    hostname: step-host-debian-10.localdomain
     groups:
       - clients
       - debian
-    image: "geerlingguy/docker-debian10-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-debian10-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_bootstrap_host
-    networks:
-      - name: smallstep_bootstrap_host
+    network: molecule-step-bootstrap-host
 
   - name: step-host-rockylinux-9
-    hostname: step-host-rockylinux-9.localdomain
     groups:
       - clients
       - rockylinux
-    image: "geerlingguy/docker-rockylinux9-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-rockylinux9-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_bootstrap_host
-    networks:
-      - name: smallstep_bootstrap_host
+    network: molecule-step-bootstrap-host
 
   - name: step-host-rockylinux-8
-    hostname: step-host-rockylinux-8.localdomain
     groups:
       - clients
       - rockylinux
-    image: "geerlingguy/docker-rockylinux8-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-rockylinux8-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_bootstrap_host
-    networks:
-      - name: smallstep_bootstrap_host
+    network: molecule-step-bootstrap-host
 
   - name: step-host-fedora-36
-    hostname: step-host-fedora-36.localdomain
     groups:
       - clients
       - fedora
-    image: "geerlingguy/docker-fedora36-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-fedora36-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
-    docker_networks:
-      - name: smallstep_bootstrap_host
-    networks:
-      - name: smallstep_bootstrap_host
+    network: molecule-step-bootstrap-host
 
 provisioner:
   name: ansible
   env:
-    ANSIBLE_PIPELINING: "True"
+    # This is required for podman to function: https://github.com/ansible-community/molecule-podman/issues/2
+    ANSIBLE_PIPELINING: false
+    #ANSIBLE_VERBOSITY: 3 # enable for debugging
   inventory:
     group_vars:
       clients:
@@ -170,7 +116,7 @@ provisioner:
         step_cli_version: ${STEP_CLI_VERSION:-latest}
         step_ca_version: ${STEP_CA_VERSION:-latest}
 
-        step_bootstrap_ca_url: https://${STEP_MOLECULE_CA_HOSTNAME:-step-ca-molecule.localdomain}:9000
+        step_bootstrap_ca_url: https://step-ca:9000
 
 scenario:
   test_sequence:

--- a/roles/step_ca/molecule/default/molecule.yml
+++ b/roles/step_ca/molecule/default/molecule.yml
@@ -2,22 +2,16 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
+  name: podman
 platforms:
-  # Note on containers:
-  # - We use the images provided by geerlingguy, as they provide out-of-the-box
-  #   support for Ansible and systemd (needed to test service management).
-  # - The containers run as privileged containers so that we can
-  #   use systemd functionality. This *should* be possible with unpriliged
-  #   containers as well, but is quite the headache.
+  # We use the images provided by geerlingguy where possible, as they provide out-of-the-box
+  # support for Ansible (pre_build_image=true, speeds up testing).
   - name: step-ca-ubuntu-22
     groups:
       - ubuntu
       - ca
-    image: "geerlingguy/docker-ubuntu2204-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-ubuntu2204-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
 
@@ -25,10 +19,8 @@ platforms:
     groups:
       - ubuntu
       - ca
-    image: "geerlingguy/docker-ubuntu2004-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
 
@@ -36,10 +28,8 @@ platforms:
     groups:
       - ubuntu
       - ca
-    image: "geerlingguy/docker-ubuntu1804-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-ubuntu1804-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
 
@@ -47,10 +37,8 @@ platforms:
     groups:
       - debian
       - ca
-    image: "geerlingguy/docker-debian11-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-debian11-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
 
@@ -58,10 +46,8 @@ platforms:
     groups:
       - debian
       - ca
-    image: "geerlingguy/docker-debian10-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-debian10-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
 
@@ -69,10 +55,8 @@ platforms:
     groups:
       - rockylinux
       - ca
-    image: "geerlingguy/docker-rockylinux9-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-rockylinux9-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
 
@@ -80,10 +64,8 @@ platforms:
     groups:
       - rockylinux
       - ca
-    image: "geerlingguy/docker-rockylinux8-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-rockylinux8-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
 
@@ -91,23 +73,25 @@ platforms:
     groups:
       - fedora
       - ca
-    image: "geerlingguy/docker-fedora36-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
+    image: "docker.io/geerlingguy/docker-fedora36-ansible"
+    systemd: always
     override_command: false
     pre_build_image: true
+
 
 provisioner:
   name: ansible
   env:
-    ANSIBLE_PIPELINING: "True"
+    # This is required for podman to function: https://github.com/ansible-community/molecule-podman/issues/2
+    ANSIBLE_PIPELINING: false
+    #ANSIBLE_VERBOSITY: 3 # enable for debugging
   inventory:
     group_vars:
       all:
-        step_cli_version: ${STEP_CLI_VERSION}
-        step_ca_version: ${STEP_CA_VERSION}
-
+        # These will be set to a concrete version if running from tox,
+        # fallback on the latest version if running molecule directly
+        step_cli_version: ${STEP_CLI_VERSION:-latest}
+        step_ca_version: ${STEP_CA_VERSION:-latest}
       ca:
         step_ca_name: Molecule Test CA
         step_ca_user: step-ca-molecule
@@ -121,7 +105,6 @@ provisioner:
         step_ca_existing_key: local
         step_ca_existing_key_file: files/molecule-ca.key
         step_ca_existing_key_password: molecule
-
 
 scenario:
   test_sequence:

--- a/roles/step_cli/molecule/default/molecule.yml
+++ b/roles/step_cli/molecule/default/molecule.yml
@@ -2,104 +2,87 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
+  name: podman
 platforms:
-  # Note on containers:
-  # - We use the images provided by geerlingguy, as they provide out-of-the-box
-  #   support for Ansible and systemd (needed to test service management).
-  # - The containers run as privileged containers so that we can
-  #   use systemd functionality. This *should* be possible with unpriliged
-  #   containers as well, but is quite the headache.
-  # - they are connected to a shared network to allow simulating a remote CA
+  # We use the images provided by geerlingguy where possible, as they provide out-of-the-box
+  # support for Ansible (pre_build_image=true, speeds up testing).
   - name: step-cli-ubuntu-22
-    image: "geerlingguy/docker-ubuntu2204-ansible"
+    image: "docker.io/geerlingguy/docker-ubuntu2204-ansible"
     groups:
       - ubuntu
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
     override_command: false
     pre_build_image: true
+    systemd: always
 
   - name: step-cli-ubuntu-20
-    image: "geerlingguy/docker-ubuntu2004-ansible"
+    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
     groups:
       - ubuntu
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
     override_command: false
     pre_build_image: true
+    systemd: always
 
   - name: step-cli-ubuntu-18
-    image: "geerlingguy/docker-ubuntu1804-ansible"
+    image: "docker.io/geerlingguy/docker-ubuntu1804-ansible"
     groups:
       - ubuntu
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
     override_command: false
     pre_build_image: true
+    systemd: always
 
   - name: step-cli-debian-11
-    image: "geerlingguy/docker-debian11-ansible"
+    image: "docker.io/geerlingguy/docker-debian11-ansible"
     groups:
       - debian
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
     override_command: false
     pre_build_image: true
+    systemd: always
 
   - name: step-cli-debian-10
-    image: "geerlingguy/docker-debian10-ansible"
+    image: "docker.io/geerlingguy/docker-debian10-ansible"
     groups:
       - debian
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
     override_command: false
     pre_build_image: true
+    systemd: always
 
   - name: step-cli-rockylinux-9
-    image: "geerlingguy/docker-rockylinux9-ansible"
+    image: "docker.io/geerlingguy/docker-rockylinux9-ansible"
     groups:
       - rockylinux
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
     override_command: false
     pre_build_image: true
+    systemd: always
 
   - name: step-cli-rockylinux-8
-    image: "geerlingguy/docker-rockylinux8-ansible"
+    image: "docker.io/geerlingguy/docker-rockylinux8-ansible"
     groups:
       - rockylinux
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
     override_command: false
     pre_build_image: true
+    systemd: always
 
   - name: step-cli-fedora-36
-    image: "geerlingguy/docker-fedora36-ansible"
+    image: "docker.io/geerlingguy/docker-fedora36-ansible"
     groups:
       - fedora
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
     override_command: false
     pre_build_image: true
+    systemd: always
 
 provisioner:
   name: ansible
   env:
-    ANSIBLE_PIPELINING: "True"
+    # This is required for podman to function: https://github.com/ansible-community/molecule-podman/issues/2
+    ANSIBLE_PIPELINING: false
+    #ANSIBLE_VERBOSITY: 3 # enable for debugging
   inventory:
     group_vars:
       all:
-        step_cli_version: ${STEP_CLI_VERSION}
-        step_ca_version: ${STEP_CA_VERSION}
+        # These will be set to a concrete version if running from tox,
+        # fallback on the latest version if running molecule directly
+        step_cli_version: ${STEP_CLI_VERSION:-latest}
+        step_ca_version: ${STEP_CA_VERSION:-latest}
         step_cli_executable: /bin/step-cli-molecule
 
 scenario:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,6 +11,8 @@ source .venv/bin/activate
 printf "Installing development requirements..."
 python3 -m pip install --upgrade pip --quiet
 python3 -m pip install --quiet -r requirements.txt --upgrade
+# Also install molecule if we need to debug something manually
+python3 -m pip install --quiet -r requirements-molecule.txt --upgrade
 printf "OK\n"
 
 printf "Installing pre-commit hook..."

--- a/tests/integration/docker/step-ca-ansible/README.md
+++ b/tests/integration/docker/step-ca-ansible/README.md
@@ -1,5 +1,5 @@
-To test module functionality, we need a ready-to-go docker image serving the smallstep CA to out target container in a docker network.
-For most tests, we can simply use the upstream image for this (see the testenv:integration section in [tox.ini](/tox.ini)).
+To test module functionality, we need a ready-to-go docker image serving the smallstep CA to our target container in a docker network.
+For most tests, we can simply use the upstream image for this (see the test-modules-integration script).
 
 However, there are modules that need direct access to the CA resources (like, on the same host) and the upstream image does not work as an ansible target by default (big surprise).
 

--- a/tests/integration/integration_config.yml.template
+++ b/tests/integration/integration_config.yml.template
@@ -18,7 +18,7 @@ ca_version: ${STEP_CA_VERSION}
 cli_version: ${STEP_CLI_VERSION}
 
 # Locally reachable CA settings - this is needed by modules like step_ca_provisioner that need FS access
-# Don't use these unless you know what you are doing
+# Don't use these unless your target is tagged with `local-ca` and you use `setup_local_ca`
 ca_user: ${STEP_LOCAL_CA_USER}
 ca_path: ${STEP_LOCAL_STEPPATH}
 cli_binary: ${STEP_LOCAL_CLI_BINARY}

--- a/tests/test-modules
+++ b/tests/test-modules
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+source ./tests/test-modules-sanity
+source ./tests/test-modules-integration

--- a/tests/test-modules-integration
+++ b/tests/test-modules-integration
@@ -6,14 +6,13 @@ set -o pipefail
 SCRIPT_DIRECTORY=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Docker settings
-export STEP_DOCKER_NETWORK="step-ansible-modules"
+export STEP_PODMAN_NETWORK="step-ansible-modules"
 
 # Remote CA settings
-export STEP_REMOTE_CA_CT_NAME="step-ca-ansible-test"
-export STEP_REMOTE_CA_CT_HOSTNAME="step-ca"
+export STEP_REMOTE_CA_CT_NAME="step-ca"
 export STEP_REMOTE_CA_PROVISIONER_NAME="ansible"
 export STEP_REMOTE_CA_PROVISIONER_PASSWORD="ansible-module-tests-pw"
-export STEP_REMOTE_CA_URL="https://$STEP_REMOTE_CA_CT_HOSTNAME:9000"
+export STEP_REMOTE_CA_URL="https://$STEP_REMOTE_CA_CT_NAME:9000"
 # FP can only evaluated when the remote docker ct is running
 export STEP_REMOTE_CA_FP=""
 
@@ -28,8 +27,8 @@ LOCAL_CA_TAG=local-ca
 cleanup() {
     echo "Cleaning up..."
     set +e # cleanup, we don't care if some stuff doesn't exist
-    docker rm -f "$STEP_REMOTE_CA_CT_NAME" > /dev/null
-    docker network rm "$STEP_DOCKER_NETWORK" > /dev/null
+    podman rm -f "$STEP_REMOTE_CA_CT_NAME" > /dev/null
+    podman network rm "$STEP_PODMAN_NETWORK" > /dev/null
     echo "Done"
     set -e
     exit
@@ -37,7 +36,7 @@ cleanup() {
 trap cleanup INT ERR EXIT
 
 prepare() {
-    docker network create $STEP_DOCKER_NETWORK
+    podman network create $STEP_PODMAN_NETWORK
 }
 
 render_config() {
@@ -49,10 +48,10 @@ render_config() {
 
 remote_ca() {
     echo "Starting remote CA container"
-    docker run -d \
-        --name $STEP_REMOTE_CA_CT_NAME --network $STEP_DOCKER_NETWORK --hostname $STEP_REMOTE_CA_CT_HOSTNAME \
+    podman run -d \
+        --name $STEP_REMOTE_CA_CT_NAME --network $STEP_PODMAN_NETWORK \
         -e "DOCKER_STEPCA_INIT_NAME=Ansible-Test" \
-        -e "DOCKER_STEPCA_INIT_DNS_NAMES=localhost,$STEP_REMOTE_CA_CT_HOSTNAME" \
+        -e "DOCKER_STEPCA_INIT_DNS_NAMES=localhost,$STEP_REMOTE_CA_CT_NAME" \
         -e "DOCKER_STEPCA_INIT_PROVISIONER_NAME=$STEP_REMOTE_CA_PROVISIONER_NAME" \
         -e "DOCKER_STEPCA_INIT_PASSWORD=$STEP_REMOTE_CA_PROVISIONER_PASSWORD" \
         "smallstep/step-ca:$STEP_CA_VERSION"
@@ -61,9 +60,9 @@ remote_ca() {
     # Give the CA a little bit to initialize
     echo "Waiting for CA to come online"
     # TODO: Check the container status with docker instead of exec-ing
-    timeout 20 bash -c "while ! docker exec $STEP_REMOTE_CA_CT_NAME step ca health &> /dev/null; do sleep 1; done"
+    timeout 20 bash -c "while ! podman exec $STEP_REMOTE_CA_CT_NAME step ca health &> /dev/null; do sleep 1; done"
 
-    STEP_REMOTE_CA_FP=$(docker exec $STEP_REMOTE_CA_CT_NAME step certificate fingerprint certs/root_ca.crt)
+    STEP_REMOTE_CA_FP=$(podman exec $STEP_REMOTE_CA_CT_NAME step certificate fingerprint certs/root_ca.crt)
     export STEP_REMOTE_CA_FP
 
     render_config
@@ -71,7 +70,7 @@ remote_ca() {
     tox -e integration -- \
         --color -v \
         --controller docker:default --target docker:default,python=3.6 \
-        --docker-network $STEP_DOCKER_NETWORK  \
+        --docker-network $STEP_PODMAN_NETWORK  \
         --skip-tags $LOCAL_CA_TAG \
         --docker-terminate=always `#Change this if you want to debug test targets`
 }
@@ -80,7 +79,7 @@ local_ca() {
     local image_name="step-ca-ansible"
 
     echo "Building docker image for local-ca test targets: $image_name with step-ca version $STEP_CA_VERSION"
-    docker build tests/integration/docker/step-ca-ansible -t $image_name \
+    podman build tests/integration/docker/step-ca-ansible -t $image_name \
         --build-arg "STEP_CA_VERSION=$STEP_CA_VERSION" \
         --build-arg "PYTHON_VERSION=$PYTHON_VERSION" \
         --build-arg "STEP_CA_USER=$STEP_LOCAL_CA_USER"
@@ -90,7 +89,7 @@ local_ca() {
     tox -e integration -- \
         --color -v \
         --controller docker:default --target "docker:$image_name,python=$PYTHON_VERSION@/usr/local/bin/python3" \
-        --docker-network $STEP_DOCKER_NETWORK  \
+        --docker-network $STEP_PODMAN_NETWORK  \
         --tags $LOCAL_CA_TAG \
         --docker-terminate=always `#Change this if you want to debug test targets`
 }

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ passenv =
 setenv =
     PY_COLORS = 1
     ANSIBLE_FORCE_COLOR = 1
+    # Enable podman for ansible-test instead of docker
+    ANSIBLE_TEST_PREFER_PODMAN = 1
 
 [testenv:sanity]
 # Pin ansible-test/core version to latest stable release, same as used for development


### PR DESCRIPTION
As discussed in #105, molecule-docker is no longer a suitable driver for our needs (specifically due to systemd support), so it's about time we switched to a container runtime that actually supports systemd.
    
With the 4.0 release, podman is finally up to the task of running our integration tests.
This change migrates molecule and ansible-test to podman and updates the contributing documentation to account for the changes.

Users that wish to test the collection locally can do so by "just" installing podman, no need to modify their docker install
(or use the god-awful unified_cgroup_hierarchy hack anymore).
However, as podman 4.0 is still relatively recent, no major distros (aside from Arch) have it in their repositories yet.
This is bound to change with the next major release of these distros, so we should hopefully be good soon.

