### PR TITLE
bump collection to step tools 0.24

### DIFF
--- a/tests/constants.sh
+++ b/tests/constants.sh
@@ -4,5 +4,5 @@
 export PYTHON_VERSION=3.6
 
 # step tools versions used for all tests
-export STEP_CA_VERSION=0.23.2
-export STEP_CLI_VERSION=0.23.4
+export STEP_CA_VERSION=0.24.1
+export STEP_CLI_VERSION=0.24.3


### PR DESCRIPTION
This pushes the collection version to 0.24, with an according version push for the collection