### PR TITLE
Add Retry functionality to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  collection-testing: maxhoesel-ansible/ansible-collection-testing@0.3.6
+  collection-testing: maxhoesel-ansible/ansible-collection-testing@0.3.8
 
 jobs:
   modules-sanity:
@@ -12,6 +12,9 @@ jobs:
       - collection-testing/install-requirements-txt
       - run:
           command: tests/test-modules-sanity
+          environment:
+            TEST_RETRIES: 3
+            TEST_RETRY_DELAY: 300
   modules-integration:
     executor: collection-testing/default
     steps:
@@ -20,6 +23,9 @@ jobs:
       - collection-testing/install-requirements-txt
       - run:
           command: tests/test-modules-integration
+          environment:
+            TEST_RETRIES: 3
+            TEST_RETRY_DELAY: 300
 
 filters: &tagged
   tags:
@@ -36,6 +42,8 @@ workflows:
       - collection-testing/tox-role-scenarios:
           parallelism: 16
           resource-class: large
+          retries: 3
+          retry-delay: 300
       - collection-testing/publish-github:
           context: collection-publishing
           filters: *tagged

--- a/tests/test-modules-integration
+++ b/tests/test-modules-integration
@@ -1,9 +1,22 @@
 #!/usr/bin/env bash
 
+# Perform integration tests on the modules
+# To keep retrying a failing test, you can set the following environment variables.
+# This is mainly intended for CI use.
+#   TEST_RETRIES=<num> - Number of times to try the test. Default: 1
+#   TEST_RETRY_DELAY=<num> - Number of seconds to wait between failing test runs. Default: 300 (5min)
+
 set -eu
 set -o pipefail
 
 SCRIPT_DIRECTORY=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck disable=1091
+source "$SCRIPT_DIRECTORY/constants.sh"
+# shellcheck disable=1091
+source "$SCRIPT_DIRECTORY/util.sh"
+
+TEST_RETRIES="${TEST_RETRIES:-1}"
+TEST_RETRY_DELAY="${TEST_RETRY_DELAY:-300}"
 
 # Docker settings
 export STEP_PODMAN_NETWORK="step-ansible-modules"
@@ -51,7 +64,7 @@ remote_ca() {
     # CircleCIs systemd session is, in some way, misconfigured and that causes some issues with podman and cgroups
     # Instead of fixing it, we can just fallback to cgroupfs
     # See: https://github.com/containers/podman/issues/16529
-    podman run --cgroup-manager=cgroupfs -d \
+    retry "$TEST_RETRIES" "$TEST_RETRY_DELAY" podman run --cgroup-manager=cgroupfs -d \
         --name $STEP_REMOTE_CA_CT_NAME --network $STEP_PODMAN_NETWORK \
         -e "DOCKER_STEPCA_INIT_NAME=Ansible-Test" \
         -e "DOCKER_STEPCA_INIT_DNS_NAMES=localhost,$STEP_REMOTE_CA_CT_NAME" \
@@ -70,7 +83,7 @@ remote_ca() {
 
     render_config
 
-    tox -e integration -- \
+    retry "$TEST_RETRIES" "$TEST_RETRY_DELAY" tox -e integration -- \
         --color -v \
         --controller docker:default --target docker:default,python=3.6 \
         --docker-network $STEP_PODMAN_NETWORK  \
@@ -85,14 +98,14 @@ local_ca() {
     # CircleCIs systemd session is, in some way, misconfigured and that causes some issues with podman and cgroups
     # Instead of fixing it, we can just fallback to cgroupfs
     # See: https://github.com/containers/podman/issues/16529
-    podman build --cgroup-manager=cgroupfs tests/integration/docker/step-ca-ansible -t $image_name \
+    retry "$TEST_RETRIES" "$TEST_RETRY_DELAY" podman build --cgroup-manager=cgroupfs tests/integration/docker/step-ca-ansible -t $image_name \
         --build-arg "STEP_CA_VERSION=$STEP_CA_VERSION" \
         --build-arg "PYTHON_VERSION=$PYTHON_VERSION" \
         --build-arg "STEP_CA_USER=$STEP_LOCAL_CA_USER"
 
     render_config
 
-    tox -e integration -- \
+    retry "$TEST_RETRIES" "$TEST_RETRY_DELAY" tox -e integration -- \
         --color -v \
         --controller docker:default --target "docker:$image_name,python=$PYTHON_VERSION@/usr/local/bin/python3" \
         --docker-network $STEP_PODMAN_NETWORK  \
@@ -101,9 +114,6 @@ local_ca() {
 }
 
 main() {
-    # shellcheck disable=1091
-    source "$SCRIPT_DIRECTORY/constants.sh"
-
     prepare
     local_ca
     remote_ca

--- a/tests/test-modules-sanity
+++ b/tests/test-modules-sanity
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
 
+# Perform sanity tests on the modules.
+# To keep retrying a failing test, you can set the following environment variables.
+# This is mainly intended for CI use.
+#   TEST_RETRIES=<num> - Number of times to try the test. Default: 1
+#   TEST_RETRY_DELAY=<num> - Number of seconds to wait between failing test runs. Default: 300 (5min)
+
 set -eu
 set -o pipefail
 
 SCRIPT_DIRECTORY=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
 # shellcheck disable=1091
 source "$SCRIPT_DIRECTORY/constants.sh"
+# shellcheck disable=1091
+source "$SCRIPT_DIRECTORY/util.sh"
+
+TEST_RETRIES="${TEST_RETRIES:-1}"
+TEST_RETRY_DELAY="${TEST_RETRY_DELAY:-300}"
 
 # As we only support py36+, pyupgrade is set to remove the py27 boilerplate. Don't check for that as we don't need it
-tox -e sanity -- \
+retry "$TEST_RETRIES" "$TEST_RETRY_DELAY" tox -e sanity -- \
     --docker --color -v \
     --python "$PYTHON_VERSION" \
     --skip-test metaclass-boilerplate --skip-test future-import-boilerplate

--- a/tests/test-roles
+++ b/tests/test-roles
@@ -1,7 +1,28 @@
 #!/usr/bin/env bash
 
+# Run tets on the roles in this collection.
+# Usage: test-roles [filter] [--help, -h]
+#
+# Run all tox molecule role scenarios that match the given filter.
+# If no filter is given, all role scenarios will be run.
+#
+# Example: ./test-roles step_ca
+#
+# To keep retrying a failing test, you can set the following environment variables.
+# This is mainly intended for CI use.
+#   TEST_RETRIES=<num> - Number of times to try the test. Default: 1
+#   TEST_RETRY_DELAY=<num> - Number of seconds to wait between failing test runs. Default: 300 (5min)
+
 set -eu
 set -o pipefail
+
+# shellcheck disable=1091
+source "$SCRIPT_DIRECTORY/constants.sh"
+# shellcheck disable=1091
+source "$SCRIPT_DIRECTORY/util.sh"
+
+TEST_RETRIES="${TEST_RETRIES:-1}"
+TEST_RETRY_DELAY="${TEST_RETRY_DELAY:-300}"
 
 # Hostname to use for the ca container in molecule scenarios
 export STEP_MOLECULE_CA_HOSTNAME=step-ca-molecule.localdomain
@@ -32,7 +53,7 @@ main() {
     fi
     set -u
 
-    tox -e "$scenarios"
+    retry "$TEST_RETRIES" "$TEST_RETRY_DELAY" tox -e "$scenarios"
 }
 
 main "$@"

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Retry a given command a number of times.
+# Usage: retry <num-of-retries> <delay-between-attempts> command with parameters just like normal
+retry() {
+  local retries=$1
+  local delay=$2
+  shift
+  shift
+
+  local count=0
+  until "$@"; do
+    exit=$?
+    count=$((count + 1))
+    if [ $count -lt "$retries" ]; then
+      echo "Retry $count/$retries exited $exit, retrying in $delay seconds..."
+      sleep "$delay"
+    else
+      echo "Retry $count/$retries exited $exit, no more retries left."
+      return $exit
+    fi
+  done
+  return 0
+}


### PR DESCRIPTION
Our CI (especially the tox tests) sometimes fail due to transient network failures, etc. To improve resilience a bit, add some basic retry logic to the big tasks themselves.