### PR TITLE
(roles): Add option to skip installing step-cli

### DIFF
--- a/roles/step_bootstrap_host/README.md
+++ b/roles/step_bootstrap_host/README.md
@@ -22,12 +22,10 @@ It will:
 
 ### Install
 
-##### `step_cli_executable`
-- What to name and where to put the `step-cli` executable that will be installed by this role
-- Can be an absolute path (make sure that the parent directory is in $PATH) or a filename
-- If this executable is not found and `step_cli_executable` is a **path**, the executable will be installed there
-- If this executable is not found and  `step_cli_executable` is a **name**, the executable will be installed at `step_cli_install_dir` with the given name
-- Default: `step-cli`
+##### `step_cli_install`
+- Whether to install the `step-cli` utility
+- Set this to `false` if the utility is already installed via other means (in this case, the role will use `step_cli_executable`)
+- Default: `true`
 
 ##### `step_cli_version`
 - Set the version of step to install
@@ -37,6 +35,13 @@ It will:
 - Note that the role will query the GitHub API if this value is set to `latest`. Try setting
   a specific version if you are running into rate limiting issues
 - Default: `latest`
+
+##### `step_cli_executable`
+- What to name and where to put the `step-cli` executable that will be installed by this role
+- Can be an absolute path (make sure that the parent directory is in $PATH) or a filename
+- If this executable is not found and `step_cli_executable` is a **path**, the executable will be installed there
+- If this executable is not found and  `step_cli_executable` is a **name**, the executable will be installed at `step_cli_install_dir` with the given name
+- Default: `step-cli`
 
 ##### `step_cli_install_dir`
 - Used if the binary defined by `step_cli_executable` is not found on the system and `step_cli_executable` contains a executable name

--- a/roles/step_bootstrap_host/defaults/main.yml
+++ b/roles/step_bootstrap_host/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
-step_cli_executable: step-cli
+step_cli_install: true
 step_cli_version: latest
+step_cli_executable: step-cli
 step_cli_install_dir: /usr/bin
 
 #step_bootstrap_ca_url:

--- a/roles/step_bootstrap_host/meta/argument_specs.yml
+++ b/roles/step_bootstrap_host/meta/argument_specs.yml
@@ -21,14 +21,12 @@ argument_specs:
         - Fedora 36 or newer
         - A CentOS-compatible distribution like RockyLinux/AlmaLinux 8 or newer. RockyLinux is used for testing
     options:
-      step_cli_executable:
-        type: path
+      step_cli_install:
+        type: bool
+        default: true
         description:
-          - What to name and where to put the C(step-cli) executable that will be installed by this role
-          - Can be an absolute path (make sure that the parent directory is in C($PATH)) or a filename
-          - If this executable is not found and I(step_cli_executable) is a B(path), the executable will be installed there
-          - If this executable is not found and I(step_cli_executable) is a B(name), the executable will be installed at I(step_cli_install_dir) with the given name
-        default: step-cli
+          - Whether to install the C(step-cli) utility
+          - Set this to C(false) if the utility is already installed via other means (in this case, the role will use C(step_cli_executable)
       step_cli_version:
         type: str
         default: latest
@@ -37,6 +35,14 @@ argument_specs:
           - Can be a version tag (e.g. C(0.15.3)), or C(latest) to always install the most recent version
           - It is B(highly) recommended that your cli version matches the collection version (e.g. if you are using the collection version C(0.20.x) you should be installing step-cli version C(0.20.x) as well)
           - Note that the role will query the GitHub API if this value is set to C(latest). Try setting a specific version if you are running into rate limiting issues
+      step_cli_executable:
+        type: path
+        description:
+          - What to name and where to put the C(step-cli) executable that will be installed by this role
+          - Can be an absolute path (make sure that the parent directory is in C($PATH)) or a filename
+          - If this executable is not found and I(step_cli_executable) is a B(path), the executable will be installed there
+          - If this executable is not found and I(step_cli_executable) is a B(name), the executable will be installed at I(step_cli_install_dir) with the given name
+        default: step-cli
       step_cli_install_dir:
         type: path
         default: "/usr/bin"

--- a/roles/step_bootstrap_host/tasks/check.yml
+++ b/roles/step_bootstrap_host/tasks/check.yml
@@ -7,6 +7,7 @@
       - step_bootstrap_fingerprint | length > 0
   when: ansible_version.string is version('2.11.1', '<')
 
-- name: Install step_cli # always run this, to ensure our cli version is up-to-date
+- name: Install step_cli # always run this (if desired), to ensure our cli version is up-to-date
   include_role:
     name: maxhoesel.smallstep.step_cli
+  when: step_cli_install

--- a/roles/step_ca/README.md
+++ b/roles/step_ca/README.md
@@ -41,12 +41,10 @@ It is thus **very** important that you **back up your root key and password** in
 
 ### Installation (step-cli)
 
-##### `step_cli_executable`
-- What to name and where to put the `step-cli` executable that will be installed by this role
-- Can be an absolute path (make sure that the parent directory is in $PATH and has correct SELinux policies set, if applicable) or a filename
-- If this executable is not found and `step_cli_executable` is a **path**, the executable will be installed there
-- If this executable is not found and  `step_cli_executable` is a **name**, the executable will be installed at `step_cli_install_dir` with the given name
-- Default: `step-cli`
+##### `step_cli_install`
+- Whether to install the `step-cli` utility
+- Set this to `false` if the utility is already installed via other means (in this case, the role will use `step_cli_executable`)
+- Default: `true`
 
 ##### `step_cli_version`
 - Set the version of step to install
@@ -56,6 +54,13 @@ It is thus **very** important that you **back up your root key and password** in
 - Note that the role will query the GitHub API if this value is set to `latest`. Try setting
   a specific version if you are running into rate limiting issues
 - Default: `latest` (same as the upstream step-cli packages)
+
+##### `step_cli_executable`
+- What to name and where to put the `step-cli` executable that will be installed by this role
+- Can be an absolute path (make sure that the parent directory is in $PATH and has correct SELinux policies set, if applicable) or a filename
+- If this executable is not found and `step_cli_executable` is a **path**, the executable will be installed there
+- If this executable is not found and  `step_cli_executable` is a **name**, the executable will be installed at `step_cli_install_dir` with the given name
+- Default: `step-cli`
 
 ##### `step_cli_install_dir`
 - Used if `step_cli_executable` is not found and contains a executable name

--- a/roles/step_ca/defaults/main.yml
+++ b/roles/step_ca/defaults/main.yml
@@ -25,5 +25,6 @@ step_ca_ssh: false
 #step_ca_ra_credentials_file:
 
 # CLI vars
+step_cli_install: true
 step_cli_executable: step-cli
 #step_cli_version: latest

--- a/roles/step_ca/meta/argument_specs.yml
+++ b/roles/step_ca/meta/argument_specs.yml
@@ -32,14 +32,12 @@ argument_specs:
 
         Storing your root key unencrypted (even just temporarily!) is strongly discouraged and poses a great security risk. This role will only decrypt the root key for as long as strictly neccessary.
     options:
-      step_cli_executable:
-        type: path
+      step_cli_install:
+        type: bool
+        default: true
         description:
-          - What to name and where to put the C(step-cli) executable that will be installed by this role
-          - Can be an absolute path (make sure that the parent directory is in C($PATH)) or a filename
-          - If this executable is not found and I(step_cli_executable) is a B(path), the executable will be installed there
-          - If this executable is not found and I(step_cli_executable) is a B(name), the executable will be installed at I(step_cli_install_dir) with the given name
-        default: step-cli
+          - Whether to install the C(step-cli) utility
+          - Set this to C(false) if the utility is already installed via other means (in this case, the role will use C(step_cli_executable)
       step_cli_version:
         type: str
         default: latest
@@ -48,6 +46,14 @@ argument_specs:
           - Can be a version tag (e.g. C(0.15.3)), or C(latest) to always install the most recent version
           - It is B(highly) recommended that your cli version matches the collection version (e.g. if you are using the collection version C(0.20.x) you should be installing step-cli version C(0.20.x) as well)
           - Note that the role will query the GitHub API if this value is set to C(latest). Try setting a specific version if you are running into rate limiting issues
+      step_cli_executable:
+        type: path
+        description:
+          - What to name and where to put the C(step-cli) executable that will be installed by this role
+          - Can be an absolute path (make sure that the parent directory is in C($PATH)) or a filename
+          - If this executable is not found and I(step_cli_executable) is a B(path), the executable will be installed there
+          - If this executable is not found and I(step_cli_executable) is a B(name), the executable will be installed at I(step_cli_install_dir) with the given name
+        default: step-cli
       step_cli_install_dir:
         type: path
         default: "/usr/bin"

--- a/roles/step_ca/tasks/check.yml
+++ b/roles/step_ca/tasks/check.yml
@@ -58,6 +58,7 @@
   when: not step_ca_intermediate_password is defined
   no_log: yes
 
-- name: Install step_cli # always run this, to ensure our cli version is also up-to-date
+- name: Install step_cli # always run this (if desired), to ensure our cli version is also up-to-date
   include_role:
     name: maxhoesel.smallstep.step_cli
+  when: step_cli_install


### PR DESCRIPTION
This PR adds a `step_cli_install` option to both `step_bootstrap_host` and `step_ca`.
This is intended for cases where the user might already have `step-cli` installed and doesn't want the roles to touch it.
