### PR TITLE
step_acme_cert: use different sudo alias name for separate instances

### DIFF
--- a/roles/step_acme_cert/README.md
+++ b/roles/step_acme_cert/README.md
@@ -17,7 +17,7 @@ The advantage of the `step` method is that no additional tools are required.
   - Debian 10 or newer
   - Fedora 36 or newer
   - A CentOS-compatible distribution like RockyLinux/AlmaLinux 8 or newer. RockyLinux is used for testing
-- This role requires root access. Make sure to run this role with `become: yes` or equivalent
+- Running this role requires root access. Make sure to run this role with `become: yes` or equivalent
 - The host must be bootstrapped with `step_bootstrap_host` and at least one user must be able to access the CA.
 
 ## Role Variables
@@ -36,7 +36,7 @@ The advantage of the `step` method is that no additional tools are required.
 
 ##### `step_acme_cert_steppath`
 - Set this if `step_acme_cert_user` requires a custom `$STEPPATH` from which to read the step config
-- ⚠️ Deprecated ⚠️ If `step_acme_cert_user` ir `root` and `step_cli_steppath` is set, this role will read the users steppath from it.
+- ⚠️ Deprecated ⚠️ If `step_acme_cert_user` is `root` and `step_cli_steppath` is set, this role will read the users steppath from it.
   This behavior exists to preserve backwards-compatibility with older role versions that could only use the root user and will be removed in a future release.
 - Example: `/etc/step-cli`
 - Default: `$HOME/.step/`

--- a/roles/step_acme_cert/molecule/converge.yml
+++ b/roles/step_acme_cert/molecule/converge.yml
@@ -26,7 +26,7 @@
         step_acme_cert_duration: 1h
         step_acme_cert_renewal_service: step-renew-webroot
         step_acme_cert_renewal_when: 59m # force renewal to happen every minute
-        step_acme_cert_renewal_reload_services: [nginx]
+        step_acme_cert_renewal_reload_services: ["nginx"]
 
     - name: Install Nginx site [Debian]
       template:

--- a/roles/step_acme_cert/molecule/verify.yml
+++ b/roles/step_acme_cert/molecule/verify.yml
@@ -11,6 +11,10 @@
           - ansible_facts.services["nginx.service"]["state"] == "running"
           - ansible_facts.services["step-renew.service"]["state"] == "running"
           - ansible_facts.services["step-renew-webroot.service"]["state"] == "running"
+      register: _res
+      retries: 3
+      delay: 5
+      until: _res is not failed
 
     - name: Wait for renewal to occur
       ansible.builtin.pause:
@@ -25,7 +29,15 @@
           - ansible_facts.services["nginx.service"]["state"] == "running"
           - ansible_facts.services["step-renew.service"]["state"] == "running"
           - ansible_facts.services["step-renew-webroot.service"]["state"] == "running"
+      register: _res
+      retries: 3
+      delay: 5
+      until: _res is not failed
 
     - name: Try to access the locally hosted site over HTTPS
       uri:
         url: "https://{{ ansible_fqdn }}"
+      register: _res
+      retries: 3
+      delay: 5
+      until: _res is not failed

--- a/roles/step_acme_cert/tasks/renewal.yml
+++ b/roles/step_acme_cert/tasks/renewal.yml
@@ -12,14 +12,25 @@
       register: _step_systemctl_binary
       changed_when: no
       check_mode: no
+    # Earlier versions of this collection used a single STEP_RENEW alias for all commands,
+    # these files should be deleted
+    - name: Old STEP_RENEW sudoers files and aliases are absent
+      file:
+        path: "/etc/sudoers.d/{{ item }}"
+        state: absent
+      loop:
+        - 99_step-renew
+        - step-renew
     - name: Step user has sudo permissions to restart required systemd units
       template:
         src: sudo-renewal.j2
-        dest: "/etc/sudoers.d/99_{{ step_acme_cert_renewal_service }}"
+        dest: "/etc/sudoers.d/99_{{ step_acme_cert_renewal_service }}_systemd"
         owner: root
         group: root
         mode: "600"
-  when: step_acme_cert_renewal_reload_services
+  when:
+    - step_acme_cert_renewal_reload_services | length > 0
+    - step_acme_cert_user != "root"
 
 - name: Renewal service is installed
   template:

--- a/roles/step_acme_cert/templates/sudo-renewal.j2
+++ b/roles/step_acme_cert/templates/sudo-renewal.j2
@@ -1,2 +1,2 @@
-Cmnd_Alias  STEP_RENEW = {{ _step_systemctl_binary.stdout }} try-reload-or-restart {{ step_acme_cert_renewal_reload_services | join(' ') }}
-{{ step_acme_cert_user }} ALL=NOPASSWD: STEP_RENEW
+Cmnd_Alias  {{ step_acme_cert_renewal_service | upper }} = {{ _step_systemctl_binary.stdout }} try-reload-or-restart {{ step_acme_cert_renewal_reload_services | join(' ') }}
+{{ step_acme_cert_user }} ALL=NOPASSWD: {{ step_acme_cert_renewal_service | upper }}


### PR DESCRIPTION
Fixes #316 

By using an alias name based on the renewal service name, multiple services can co-exist in the sudoers configuration at the same time. The user is still required to set a unique name for each renewal service instance, as mentioned in the README.

To ensure that any old configs are wiped, this PR also slightly changes the naming scheme for the sudoer files