### PR TITLE
breaking: bump node python requirement to 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ workflows:
             parameters:
               ansible-version: ["2.15", "2.14"]
               step-version: ["latest", "compat"]
-              node-python-version: ["3.6"]
+              node-python-version: ["3.7"]
       - collection-testing/pre-commit-lint:
           name: Lint
       - collection-testing/antsibull-docs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,11 @@ The CI also builds the docs to ensure they don't break silently.
 
 1. Update the versions in the [CI config](./.circleci/config.yml)
 
+### Bumping node python version
+
+1. Update the version in [`tests/conftest.py`](./tests/conftest.py)
+2. Update the version in the [CI config](./.circleci/config.yml)
+
 ### Versioning and Releases
 
 - Releases are automatically drafted by `release-drafter`, with a changelog generated from PR labels

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ and the [CLI tool](https://github.com/smallstep/cli). Possible uses for this col
 
 - A recent release of Ansible. This collection is tested against the 2 most recent Ansible releases.
   Older versions might still work, but are not supported
-- Python 3.6 or newer on the target nodes
+- Python 3.7 or newer on the target nodes
 
 Individual roles or modules may have additional dependencies, please check their respective documentation.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,10 @@ import pytest
 from pytest_virtualenv import VirtualEnv
 import yaml
 
+NODE_PYTHON_DEFAULT_VERSION = "3.7"
+STEP_CLI_DEFAULT_VERSION = "latest"
+STEP_CA_DEFAULT_VERSION = "latest"
+
 with open("galaxy.yml", encoding="utf-8") as f:
     GALAXY_YML = yaml.safe_load(f)
 
@@ -32,12 +36,15 @@ def get_ansible_version():
 def pytest_addoption(parser):
     parser.addoption("--ansible-version", action="store", default=get_ansible_version(),
                      help="Version of ansible to use for tests, in the format '2.xx'. Default: see requirements.txt")
-    parser.addoption("--step-cli-version", action="store", default="latest",
-                     help="Version of step-cli to use for tests, either 'latest' (default) or a version ('0.24.0')")
-    parser.addoption("--step-ca-version", action="store", default="latest",
-                     help="Version of step-ca to use for tests, either 'latest' (default) or a version ('0.24.0')")
-    parser.addoption("--node-python-version", action="store", default="3.6",
-                     help="Python version to test Ansible modules with, in the format '3.x'. Default: '3.6'")
+    parser.addoption("--step-cli-version", action="store", default=STEP_CLI_DEFAULT_VERSION,
+                     help="Version of step-cli to use for tests, "
+                     f"either '{STEP_CLI_DEFAULT_VERSION}' (default) or a version ('0.24.0')")
+    parser.addoption("--step-ca-version", action="store", default=STEP_CA_DEFAULT_VERSION,
+                     help="Version of step-ca to use for tests, "
+                     f"either '{STEP_CA_DEFAULT_VERSION}' (default) or a version ('0.24.0')")
+    parser.addoption("--node-python-version", action="store", default=NODE_PYTHON_DEFAULT_VERSION,
+                     help="Python version to test Ansible modules with, "
+                     f"in the format '3.x'. Default: '{NODE_PYTHON_DEFAULT_VERSION}'")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
A spart of the effort for the 1.x release, most of the modules and module_utils are going to see a significant rework.
One of the key improvements will be the inclusion of type hints, which require Python 3.7.

The current state of the refactor can be seen here: https://github.com/maxhoesel/ansible-collection-smallstep-fork/tree/refactor_modules

This PR drops 3.6 from the modules tests. Future PRs may also drop support for distributions still running Python 3.6

