### PR TITLE
modules: remove stderr/stdout from output, make revoke idempotent

### DIFF
--- a/plugins/modules/step_ca_bootstrap.py
+++ b/plugins/modules/step_ca_bootstrap.py
@@ -53,7 +53,7 @@ EXAMPLES = r"""
 
 import json
 import os
-from typing import Dict, cast
+from typing import Dict, cast, Any
 
 from ansible.module_utils.basic import AnsibleModule
 from ..module_utils.cli_wrapper import CLIWrapper
@@ -70,7 +70,7 @@ def run_module():
         redirect_url=dict(),
         step_cli_executable=dict(type="path", default="step-cli")
     )
-    result = dict(changed=False, stdout="", stderr="", msg="")
+    result: Dict[str, Any] = dict(changed=False)
     module = AnsibleModule(argument_spec, supports_check_mode=True)
     module_params = cast(Dict, module.params)
 
@@ -99,7 +99,7 @@ def run_module():
         "install": "--install",
         "redirect_url": "--redirect-url",
     })
-    result["stdout"], result["stderr"] = cli.run_command(cli_params)[1:3]
+    cli.run_command(cli_params)
     result["changed"] = True
     module.exit_json(**result)
 

--- a/plugins/modules/step_ca_certificate.py
+++ b/plugins/modules/step_ca_certificate.py
@@ -161,7 +161,7 @@ EXAMPLES = r"""
     key_file: /tmp/mycert.key
 """
 
-from typing import cast, Dict
+from typing import cast, Dict, Any
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -198,7 +198,7 @@ def run_module():
         x5c_key=dict(type="path"),
         step_cli_executable=dict(type="path", default=DEFAULT_STEP_CLI_EXECUTABLE)
     )
-    result = dict(changed=False, stdout="", stderr="", msg="")
+    result: Dict[str, Any] = dict(changed=False)
     module = AnsibleModule(argument_spec={
         **CaConnectionParams.argument_spec,
         **argument_spec,
@@ -223,7 +223,7 @@ def run_module():
         **CaConnectionParams.cliarg_map
     })
 
-    result["stdout"], result["stderr"] = cli.run_command(cli_params)[1:3]
+    cli.run_command(cli_params)
     result["changed"] = True
     module.exit_json(**result)
 

--- a/plugins/modules/step_ca_renew.py
+++ b/plugins/modules/step_ca_renew.py
@@ -73,7 +73,7 @@ EXAMPLES = r"""
     force: yes
 """
 
-from typing import Dict, cast
+from typing import Dict, cast, Any
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -96,7 +96,7 @@ def run_module():
         signal=dict(type="int"),
         step_cli_executable=dict(type="path", default=DEFAULT_STEP_CLI_EXECUTABLE),
     )
-    result = dict(changed=False, stdout="", stderr="", msg="")
+    result: Dict[str, Any] = dict(changed=False)
     module = AnsibleModule(argument_spec={
         **CaConnectionParams.argument_spec,
         **argument_spec
@@ -118,8 +118,8 @@ def run_module():
         **CaConnectionParams.cliarg_map
     })
 
-    result["stdout"], result["stderr"] = cli.run_command(cli_params)[1:3]
-    if "Your certificate has been saved in" in result["stderr"]:
+    stderr = cli.run_command(cli_params)[2]
+    if "Your certificate has been saved in" in stderr:
         result["changed"] = True
     module.exit_json(**result)
 

--- a/plugins/modules/step_ca_token.py
+++ b/plugins/modules/step_ca_token.py
@@ -135,7 +135,7 @@ token:
   type: str
   no_log: yes
 """
-from typing import cast, Dict
+from typing import cast, Dict, Any
 
 from ansible.module_utils.common.validation import check_required_one_of
 from ansible.module_utils.common.validation import check_mutually_exclusive
@@ -174,8 +174,7 @@ def run_module():
         x5c_key=dict(type="path"),
         step_cli_executable=dict(type="path", default=DEFAULT_STEP_CLI_EXECUTABLE)
     )
-
-    result = dict(changed=False, stdout="", stderr="", msg="")
+    result: Dict[str, Any] = dict(changed=False)
     module = AnsibleModule(argument_spec={
         **CaConnectionParams.argument_spec,
         **argument_spec
@@ -212,12 +211,10 @@ def run_module():
         **CaConnectionParams.cliarg_map
     })
 
-    result["stdout"], result["stderr"] = cli.run_command(cli_params)[1:3]
+    stdout = cli.run_command(cli_params)[1]
     result["changed"] = True
     if module_params["return_token"]:
-        result["token"] = result["stdout"]
-    result["stdout"] = ""
-    result["stdout_lines"] = ""
+        result["token"] = stdout
     module.exit_json(**result)
 
 

--- a/tests/integration/targets/step_ca_revoke/tasks/main.yml
+++ b/tests/integration/targets/step_ca_revoke/tasks/main.yml
@@ -15,10 +15,20 @@
     reason: "Testing cert revocation"
     reason_code: 1
   register: revocation
-
 - name: Verify that cert got revoked
   assert:
     that: revocation.changed
+
+- name: Try to revoke cert again
+  maxhoesel.smallstep.step_ca_revoke:
+    cert: /tmp/generated_certificate
+    key: /tmp/generated_key
+    reason: "Testing cert revocation"
+    reason_code: 1
+  register: revocation_again
+- name: Verify that nothing changed
+  assert:
+    that: not revocation_again.changed
 
 - name: Delete generated files
   file:


### PR DESCRIPTION
This PR removes the `stdout` and `stderr` parameters from all module return values. These values were never documented, but since someone might still have used them this considered a breaking change nonetheless.

In addition, `step_ca_revoke` is now idempotent by checking if the certificate actually got revoked or not