### PR TITLE
roles: ensure binaries are owned by root

### DIFF
--- a/roles/step_ca/tasks/install.yml
+++ b/roles/step_ca/tasks/install.yml
@@ -52,6 +52,17 @@
         executable: /bin/bash
       notify: restart step-ca
       when: step_ca_version is version("0.25.2", ">=")
+    - name: Restore SELinux context for binary # noqa no-changed-when
+      command: "restorecon -v {{ step_ca_executable }}"
+      when: ansible_selinux is defined and ansible_selinux and ansible_selinux.status == 'enabled'
+    - name: Ensure binary is owned by root
+      ansible.builtin.file:
+        path: "{{ step_ca_executable }}"
+        state: file
+        owner: root
+        group: root
+        mode: "755"
+
   always:
     - name: Remove step release archive
       file:

--- a/roles/step_cli/tasks/install.yml
+++ b/roles/step_cli/tasks/install.yml
@@ -37,6 +37,14 @@
     - name: Restore SELinux context for binary
       command: "restorecon -v {{ _step_cli_install_path }}"
       when: ansible_selinux is defined and ansible_selinux and ansible_selinux.status == 'enabled'
+    - name: Ensure binary is owned by root
+      ansible.builtin.file:
+        path: "{{ _step_cli_install_path }}"
+        state: file
+        owner: root
+        group: root
+        mode: "755"
+
   always:
     - name: Remove step release archive
       file:


### PR DESCRIPTION
This addresses a potentially security-critical issue described in #371 , where due to unchanged ownership, a normal user may have been able to modify/replace the step-cli and step-ca binaries.