### PR TITLE
Add missing dash to new-password-file arg when setting intermediate key passwd

### DIFF
--- a/roles/step_ca/tasks/init.yml
+++ b/roles/step_ca/tasks/init.yml
@@ -93,7 +93,7 @@
       become_user: "{{ step_ca_user }}"
 
     - name: Change password for intermediate and ssh keys # noqa no-changed-when
-      command: "{{ step_cli_executable }} crypto change-pass {{ step_ca_path }}/secrets/{{ item }} -f --password-file={{ step_ca_root_password_file }} -new-password-file={{ step_ca_intermediate_password_file }}"
+      command: "{{ step_cli_executable }} crypto change-pass {{ step_ca_path }}/secrets/{{ item }} -f --password-file={{ step_ca_root_password_file }} --new-password-file={{ step_ca_intermediate_password_file }}"
       become: yes
       become_user: "{{ step_ca_user }}"
       loop: "{{ _item_list | select | list }}"


### PR DESCRIPTION
Single character change to match the argument "--new-password-file" when updating the intermediate key file password.