### PR TITLE
roles: fix step_cli_install var being overwritten

### DIFF
--- a/roles/step_acme_cert/tasks/check.yml
+++ b/roles/step_acme_cert/tasks/check.yml
@@ -1,12 +1,12 @@
 - name: Look for step_cli_executable # noqa command-instead-of-shell
   #"command" is a shell builtin, hence the need for the shell module
   shell: "command -v {{ step_cli_executable }}"
-  register: step_cli_install
+  register: _step_cli_install
   # dash (Debian sh shell) uses 127 instead of 1 for not found errors
-  failed_when: step_cli_install.rc not in [0,1,127]
+  failed_when: _step_cli_install.rc not in [0,1,127]
   changed_when: no
   check_mode: no
 - name: Verify that `step-cli` is installed
   assert:
-    that: step_cli_install.rc == 0
+    that: _step_cli_install.rc == 0
     fail_msg: "Could not find step-cli at path '{{ step_cli_executable }}'. Please install step-cli via maxhoesel.smallstep.step_cli or step_bootstrap_host"

--- a/roles/step_cli/tasks/install.yml
+++ b/roles/step_cli/tasks/install.yml
@@ -1,9 +1,9 @@
 - name: Look for step_cli_executable # noqa command-instead-of-shell
   #"command" is a shell builtin, hence the need for the shell module
   shell: "command -v {{ step_cli_executable }}"
-  register: step_cli_install
+  register: _step_cli_install
   # dash (Debian sh shell) uses 127 instead of 1 for not found errors
-  failed_when: step_cli_install.rc not in [0,1,127]
+  failed_when: _step_cli_install.rc not in [0,1,127]
   changed_when: no
   check_mode: no
 
@@ -16,7 +16,7 @@
   changed_when: no
   check_mode: no
   register: step_cli_installed_version
-  when: step_cli_install.rc == 0
+  when: _step_cli_install.rc == 0
 
 - name: Install step-cli
   block:


### PR DESCRIPTION
this patch renames the internal variables used by the roles to determine
whether step-cli is installed to a different value than the user-facing
`step_cli_install` variable that toggles installation.

Fixes a case where a user that set step_cli_install as a role variable
in their playbook would get errors about step_cli_install being a bool
and not having an RC object due to the internal var being overwritten.
