### PR TITLE
step_ca: fix failure on ipv6-only networks

### DIFF
--- a/roles/step_ca/README.md
+++ b/roles/step_ca/README.md
@@ -116,7 +116,8 @@ See the [step docs](https://smallstep.com/docs/step-cli/reference/ca/init) for m
 
 ##### `step_ca_dns`
 - The comma separated DNS names or IP addresses of the new CA
-- Default: `{{ ansible_fqdn}},{{ ansible_default_ipv4.address }}`
+- Includes the hosts FQDN and main IPv4/6 addresses by default, if present
+- Default: `"{{ ansible_fqdn }},{{ ansible_default_ipv4.address | d('') }},{{ ansible_default_ipv6.address | d('') }}"`
 
 ##### `step_ca_address`
 - The address that the new CA will listen at

--- a/roles/step_ca/defaults/main.yml
+++ b/roles/step_ca/defaults/main.yml
@@ -9,7 +9,8 @@ step_ca_path: /etc/step-ca
 #step_ca_name:
 #step_ca_root_password:
 #step_ca_intermediate_password:
-step_ca_dns: "{{ ansible_fqdn }},{{ ansible_default_ipv4.address }}"
+# step-ca init skips empty entries, so this works
+step_ca_dns: "{{ ansible_fqdn }},{{ ansible_default_ipv4.address | d('') }},{{ ansible_default_ipv6.address | d('') }}"
 step_ca_address: ":443"
 
 #step_ca_existing_root:

--- a/roles/step_ca/meta/argument_specs.yml
+++ b/roles/step_ca/meta/argument_specs.yml
@@ -101,8 +101,10 @@ argument_specs:
           - If unset, uses the root password will be used as the intermediate password
       step_ca_dns:
         type: str
-        default: "{{ ansible_fqdn}},{{ ansible_default_ipv4.address }}"
-        description: The comma separated DNS names or IP addresses of the new CA
+        default: "{{ ansible_fqdn }},{{ ansible_default_ipv4.address | d('') }},{{ ansible_default_ipv6.address | d('') }}"
+        description:
+          - The comma separated DNS names or IP addresses of the new CA
+          - Includes the hosts FQDN and main IPv4/6 addresses by default, if present
       step_ca_address:
         type: str
         default: :443


### PR DESCRIPTION
The `step_ca` role currently assumes that any step-ca host will always have at least one IPv4 address assigned. However, some users may want to run an IPv6-only CA, which fails with the current default setting for `step_ca_dns`. 

This change addresses that by changing `step_ca_dns` to opportunisitically include default IPv4 and IPv6 addresses, if present. If this behavior is undesirable, users can always override `step_ca_dns` themselves

Fixes #385.

