### PR TITLE
roles: update supported distros, remove older distros

### DIFF
--- a/roles/step_acme_cert/README.md
+++ b/roles/step_acme_cert/README.md
@@ -12,11 +12,12 @@ The advantage of the `step` method is that no additional tools are required.
 
 ## Requirements
 
-- The following distributions are currently supported:
-  - Ubuntu 18.04 LTS or newer
-  - Debian 10 or newer
-  - Fedora 36 or newer
-  - A CentOS-compatible distribution like RockyLinux/AlmaLinux 8 or newer. RockyLinux is used for testing
+- The following distributions are currently supported and tested:
+  - Ubuntu: `20.04 LTS, 22.04 LTS`
+  - Debian: `11, 12`
+  - Fedora: `38, 39`
+  - RHEL(-compatible): `9` (RockyLinux is used for testing)
+  - Other distributions may work as well, but are not tested
 - Running this role requires root access. Make sure to run this role with `become: yes` or equivalent
 - The host must be bootstrapped with `step_bootstrap_host` and at least one user must be able to access the CA.
 

--- a/roles/step_acme_cert/molecule/default/molecule.yml
+++ b/roles/step_acme_cert/molecule/default/molecule.yml
@@ -41,11 +41,11 @@ platforms:
     networks:
       - name: molecule-step-acme-cert
 
-  - name: step-host-ubuntu-18
+  - name: step-host-debian-12
     groups:
       - clients
-      - ubuntu
-    image: "docker.io/geerlingguy/docker-ubuntu1804-ansible"
+      - debian
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -69,20 +69,6 @@ platforms:
     networks:
       - name: molecule-step-acme-cert
 
-  - name: step-host-debian-10
-    groups:
-      - clients
-      - debian
-    image: "docker.io/geerlingguy/docker-debian10-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    override_command: false
-    pre_build_image: true
-    networks:
-      - name: molecule-step-acme-cert
-
   - name: step-host-rockylinux-9
     groups:
       - clients
@@ -97,11 +83,11 @@ platforms:
     networks:
       - name: molecule-step-acme-cert
 
-  - name: step-host-rockylinux-8
+  - name: step-host-fedora-39
     groups:
       - clients
-      - rockylinux
-    image: "docker.io/geerlingguy/docker-rockylinux8-ansible"
+      - fedora
+    image: "docker.io/geerlingguy/docker-fedora39-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -111,11 +97,11 @@ platforms:
     networks:
       - name: molecule-step-acme-cert
 
-  - name: step-host-fedora-36
+  - name: step-host-fedora-38
     groups:
       - clients
       - fedora
-    image: "docker.io/geerlingguy/docker-fedora36-ansible"
+    image: "docker.io/geerlingguy/docker-fedora38-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/step_acme_cert/molecule/non_root/molecule.yml
+++ b/roles/step_acme_cert/molecule/non_root/molecule.yml
@@ -41,11 +41,11 @@ platforms:
     networks:
       - name: molecule-step-acme-cert
 
-  - name: step-host-ubuntu-18
+  - name: step-host-debian-12
     groups:
       - clients
-      - ubuntu
-    image: "docker.io/geerlingguy/docker-ubuntu1804-ansible"
+      - debian
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -69,20 +69,6 @@ platforms:
     networks:
       - name: molecule-step-acme-cert
 
-  - name: step-host-debian-10
-    groups:
-      - clients
-      - debian
-    image: "docker.io/geerlingguy/docker-debian10-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    override_command: false
-    pre_build_image: true
-    networks:
-      - name: molecule-step-acme-cert
-
   - name: step-host-rockylinux-9
     groups:
       - clients
@@ -97,11 +83,11 @@ platforms:
     networks:
       - name: molecule-step-acme-cert
 
-  - name: step-host-rockylinux-8
+  - name: step-host-fedora-39
     groups:
       - clients
-      - rockylinux
-    image: "docker.io/geerlingguy/docker-rockylinux8-ansible"
+      - fedora
+    image: "docker.io/geerlingguy/docker-fedora39-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -111,11 +97,11 @@ platforms:
     networks:
       - name: molecule-step-acme-cert
 
-  - name: step-host-fedora-36
+  - name: step-host-fedora-38
     groups:
       - clients
       - fedora
-    image: "docker.io/geerlingguy/docker-fedora36-ansible"
+    image: "docker.io/geerlingguy/docker-fedora38-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/step_bootstrap_host/README.md
+++ b/roles/step_bootstrap_host/README.md
@@ -10,11 +10,12 @@ It will:
 
 ## Requirements
 
-- The following distributions are currently supported:
-  - Ubuntu 18.04 LTS or newer
-  - Debian 10 or newer
-  - Fedora 36 or newer
-  - A CentOS-compatible distribution like RockyLinux/AlmaLinux 8 or newer. RockyLinux is used for testing
+- The following distributions are currently supported and tested:
+  - Ubuntu: `20.04 LTS, 22.04 LTS`
+  - Debian: `11, 12`
+  - Fedora: `38, 39`
+  - RHEL(-compatible): `9` (RockyLinux is used for testing)
+  - Other distributions may work as well, but are not tested
 - This role requires root access. Make sure to run this role with `become: yes` or equivalent
 - `step-cli` will be automatically installed, if not already present
 

--- a/roles/step_bootstrap_host/molecule/default/molecule.yml
+++ b/roles/step_bootstrap_host/molecule/default/molecule.yml
@@ -42,11 +42,11 @@ platforms:
     networks:
       - name: molecule-step-bootstrap-host
 
-  - name: step-host-ubuntu-18
+  - name: step-host-debian-12
     groups:
       - clients
-      - ubuntu
-    image: "docker.io/geerlingguy/docker-ubuntu1804-ansible"
+      - debian
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -70,20 +70,6 @@ platforms:
     networks:
       - name: molecule-step-bootstrap-host
 
-  - name: step-host-debian-10
-    groups:
-      - clients
-      - debian
-    image: "docker.io/geerlingguy/docker-debian10-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    override_command: false
-    pre_build_image: true
-    networks:
-      - name: molecule-step-bootstrap-host
-
   - name: step-host-rockylinux-9
     groups:
       - clients
@@ -98,11 +84,11 @@ platforms:
     networks:
       - name: molecule-step-bootstrap-host
 
-  - name: step-host-rockylinux-8
+  - name: step-host-fedora-39
     groups:
       - clients
-      - rockylinux
-    image: "docker.io/geerlingguy/docker-rockylinux8-ansible"
+      - fedora
+    image: "docker.io/geerlingguy/docker-fedora39-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -112,11 +98,11 @@ platforms:
     networks:
       - name: molecule-step-bootstrap-host
 
-  - name: step-host-fedora-36
+  - name: step-host-fedora-38
     groups:
       - clients
       - fedora
-    image: "docker.io/geerlingguy/docker-fedora36-ansible"
+    image: "docker.io/geerlingguy/docker-fedora38-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/step_bootstrap_host/molecule/multi_user/molecule.yml
+++ b/roles/step_bootstrap_host/molecule/multi_user/molecule.yml
@@ -42,11 +42,11 @@ platforms:
     networks:
       - name: molecule-step-bootstrap-host
 
-  - name: step-host-ubuntu-18
+  - name: step-host-debian-12
     groups:
       - clients
-      - ubuntu
-    image: "docker.io/geerlingguy/docker-ubuntu1804-ansible"
+      - debian
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -70,20 +70,6 @@ platforms:
     networks:
       - name: molecule-step-bootstrap-host
 
-  - name: step-host-debian-10
-    groups:
-      - clients
-      - debian
-    image: "docker.io/geerlingguy/docker-debian10-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    override_command: false
-    pre_build_image: true
-    networks:
-      - name: molecule-step-bootstrap-host
-
   - name: step-host-rockylinux-9
     groups:
       - clients
@@ -98,11 +84,11 @@ platforms:
     networks:
       - name: molecule-step-bootstrap-host
 
-  - name: step-host-rockylinux-8
+  - name: step-host-fedora-39
     groups:
       - clients
-      - rockylinux
-    image: "docker.io/geerlingguy/docker-rockylinux8-ansible"
+      - fedora
+    image: "docker.io/geerlingguy/docker-fedora39-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -112,11 +98,11 @@ platforms:
     networks:
       - name: molecule-step-bootstrap-host
 
-  - name: step-host-fedora-36
+  - name: step-host-fedora-38
     groups:
       - clients
       - fedora
-    image: "docker.io/geerlingguy/docker-fedora36-ansible"
+    image: "docker.io/geerlingguy/docker-fedora38-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/step_ca/README.md
+++ b/roles/step_ca/README.md
@@ -29,11 +29,12 @@ It is thus **very** important that you **back up your root key and password** in
 
 ## Requirements
 
-- The following distributions are currently supported:
-  - Ubuntu 18.04 LTS or newer
-  - Debian 10 or newer
-  - Fedora 36 or newer
-  - A CentOS-compatible distribution like RockyLinux/AlmaLinux 8 or newer. RockyLinux is used for testing
+- The following distributions are currently supported and tested:
+  - Ubuntu: `20.04 LTS, 22.04 LTS`
+  - Debian: `11, 12`
+  - Fedora: `38, 39`
+  - RHEL(-compatible): `9` (RockyLinux is used for testing)
+  - Other distributions may work as well, but are not tested
 - Supported architectures: amd64, arm64
 - This role requires root access. Make sure to run this role with `become: yes` or equivalent
 

--- a/roles/step_ca/molecule/default/molecule.yml
+++ b/roles/step_ca/molecule/default/molecule.yml
@@ -23,11 +23,11 @@ platforms:
     override_command: false
     pre_build_image: true
 
-  - name: step-ca-ubuntu-18
+  - name: step-ca-debian-12
     groups:
-      - ubuntu
+      - debian
       - ca
-    image: "docker.io/geerlingguy/docker-ubuntu1804-ansible"
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -47,18 +47,6 @@ platforms:
     override_command: false
     pre_build_image: true
 
-  - name: step-ca-debian-10
-    groups:
-      - debian
-      - ca
-    image: "docker.io/geerlingguy/docker-debian10-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    override_command: false
-    pre_build_image: true
-
   - name: step-ca-rockylinux-9
     groups:
       - rockylinux
@@ -71,23 +59,11 @@ platforms:
     override_command: false
     pre_build_image: true
 
-  - name: step-ca-rockylinux-8
-    groups:
-      - rockylinux
-      - ca
-    image: "docker.io/geerlingguy/docker-rockylinux8-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    override_command: false
-    pre_build_image: true
-
-  - name: step-ca-fedora-36
+  - name: step-ca-fedora-39
     groups:
       - fedora
       - ca
-    image: "docker.io/geerlingguy/docker-fedora36-ansible"
+    image: "docker.io/geerlingguy/docker-fedora39-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -95,6 +71,17 @@ platforms:
     override_command: false
     pre_build_image: true
 
+  - name: step-ca-fedora-38
+    groups:
+      - fedora
+      - ca
+    image: "docker.io/geerlingguy/docker-fedora38-ansible"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    override_command: false
+    pre_build_image: true
 
 provisioner:
   inventory:

--- a/roles/step_cli/README.md
+++ b/roles/step_cli/README.md
@@ -6,11 +6,12 @@ This role is used by `step_bootstrap_host` and `step_ca`, but can also be used s
 
 ## Requirements
 
-- The following distributions are currently supported:
-  - Ubuntu 18.04 LTS or newer
-  - Debian 10 or newer
-  - Fedora 38 or newer
-  - A CentOS-compatible distribution like RockyLinux/AlmaLinux 8 or newer. RockyLinux is used for testing
+- The following distributions are currently supported and tested:
+  - Ubuntu: `20.04 LTS, 22.04 LTS`
+  - Debian: `11, 12`
+  - Fedora: `38, 39`
+  - RHEL(-compatible): `9` (RockyLinux is used for testing)
+  - Other distributions may work as well, but are not tested
 - Supported architectures: amd64, arm64
 - This role requires root access. Make sure to run this role with `become: yes` or equivalent
 

--- a/roles/step_cli/molecule/default/molecule.yml
+++ b/roles/step_cli/molecule/default/molecule.yml
@@ -21,19 +21,8 @@ platforms:
     cgroupns_mode: host
     privileged: true
 
-  - name: step-cli-ubuntu-18
-    image: "docker.io/geerlingguy/docker-ubuntu1804-ansible"
-    groups:
-      - ubuntu
-    override_command: false
-    pre_build_image: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-
-  - name: step-cli-debian-11
-    image: "docker.io/geerlingguy/docker-debian11-ansible"
+  - name: step-cli-debian-12
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
     groups:
       - debian
     override_command: false
@@ -43,8 +32,8 @@ platforms:
     cgroupns_mode: host
     privileged: true
 
-  - name: step-cli-debian-10
-    image: "docker.io/geerlingguy/docker-debian10-ansible"
+  - name: step-cli-debian-11
+    image: "docker.io/geerlingguy/docker-debian11-ansible"
     groups:
       - debian
     override_command: false
@@ -76,8 +65,19 @@ platforms:
     cgroupns_mode: host
     privileged: true
 
-  - name: step-cli-fedora-36
-    image: "docker.io/geerlingguy/docker-fedora36-ansible"
+  - name: step-cli-fedora-39
+    image: "docker.io/geerlingguy/docker-fedora39-ansible"
+    groups:
+      - fedora
+    override_command: false
+    pre_build_image: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+
+  - name: step-cli-fedora-38
+    image: "docker.io/geerlingguy/docker-fedora38-ansible"
     groups:
       - fedora
     override_command: false


### PR DESCRIPTION
This commit updates the tested distributions to Debian 12 and
Fedora 39. The following distros will soon see the end of their
mainstream support period, so we drop them from our test roster:

Ubuntu 18.04
Debian 10
RockyLinux/AlmaLinux 8

Ubuntu and RockyLinux in particular still shipped with older python
versions than we now officially support (3.6 vs 3.7), so removing them
should prevent conflicts and confusion.

Fedora 36 has already lost support status over a year ago, so about time
we update that version to something more recent.