### PR TITLE
modules: factor out cliargs into separate dataclass

### DIFF
--- a/plugins/module_utils/helpers.py
+++ b/plugins/module_utils/helpers.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Dict, Any
 
 from ansible.module_utils.basic import AnsibleModule
-from ..module_utils.cli_wrapper import CliCommand, StepCliExecutable
+from ..module_utils.cli_wrapper import CliCommand, StepCliExecutable, CliCommandArgs
 
 
 @dataclass
@@ -42,7 +42,7 @@ def get_certificate_info(
     if roots:
         inspect_args.extend(["--roots", roots])
 
-    inspect_cmd = CliCommand(executable, inspect_args, run_in_check_mode=True)
+    inspect_cmd = CliCommand(executable, CliCommandArgs(inspect_args), run_in_check_mode=True)
     inspect_res = inspect_cmd.run(module)
     # The docs say inspect outputs to stderr, but my shell says otherwise:
     # https://github.com/smallstep/cli/issues/1032
@@ -56,7 +56,7 @@ def get_certificate_info(
         verify_args.extend(["--server-name", server_name])
     if roots:
         verify_args.extend(["--roots", roots])
-    verify_cmd = CliCommand(executable, verify_args, run_in_check_mode=True, fail_on_error=False)
+    verify_cmd = CliCommand(executable, CliCommandArgs(verify_args), run_in_check_mode=True, fail_on_error=False)
     verify_res = verify_cmd.run(module)
     valid = verify_res.rc == 0
     invalid_reason = "" if valid else verify_res.stderr

--- a/plugins/module_utils/params/ca_admin.py
+++ b/plugins/module_utils/params/ca_admin.py
@@ -6,6 +6,7 @@ from typing import Dict, Any
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common import validation
 
+from ..cli_wrapper import CliCommandArgs
 from .params_helper import ParamsHelper
 
 
@@ -18,7 +19,10 @@ class AdminParams(ParamsHelper):
         admin_subject=dict(type="str", aliases=["admin_name"]),
         admin_password_file=dict(type="path", no_log=False)
     )
-    cliarg_map: Dict[str, str] = {key: f"--{key.replace('_', '-')}" for key in argument_spec}
+
+    @classmethod
+    def cli_args(cls) -> CliCommandArgs:
+        return CliCommandArgs([], {key: f"--{key.replace('_', '-')}" for key in cls.argument_spec})
 
     # pylint: disable=useless-parent-delegation
     def __init__(self, module: AnsibleModule) -> None:

--- a/plugins/module_utils/params/ca_connection.py
+++ b/plugins/module_utils/params/ca_connection.py
@@ -5,6 +5,7 @@ from typing import Dict, Any
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ..cli_wrapper import CliCommandArgs
 from .params_helper import ParamsHelper
 
 
@@ -16,7 +17,10 @@ class CaConnectionParams(ParamsHelper):
         ca_config=dict(type="path"),
         offline=dict(type="bool"),
     )
-    cliarg_map: Dict[str, str] = {key: f"--{key.replace('_', '-')}" for key in argument_spec}
+
+    @classmethod
+    def cli_args(cls) -> CliCommandArgs:
+        return CliCommandArgs([], {key: f"--{key.replace('_', '-')}" for key in cls.argument_spec})
 
     # pylint: disable=useless-parent-delegation
     def __init__(self, module: AnsibleModule) -> None:

--- a/plugins/module_utils/params/params_helper.py
+++ b/plugins/module_utils/params/params_helper.py
@@ -3,6 +3,8 @@ from typing import Dict, Any
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ..cli_wrapper import CliCommandArgs
+
 
 class ParamsHelper(ABC):
     """A helper class that provides a set of module parameters and a method to validate them.
@@ -27,8 +29,8 @@ class ParamsHelper(ABC):
         """Returns the helpers argument spec, as expected by AnsibleModule()
         """
 
-    @property
+    @classmethod
     @abstractmethod
-    def cliarg_map(self) -> Dict[str, str]:
-        """Returns a map of params with their corresponding cli parameter, for use in CliWrapper
+    def cli_args(cls) -> CliCommandArgs:
+        """Returns a CliCommandArgs object containing all the arguments needed for this parameter group
         """

--- a/plugins/modules/step_ca_bootstrap.py
+++ b/plugins/modules/step_ca_bootstrap.py
@@ -56,7 +56,7 @@ import os
 from typing import Dict, cast, Any
 
 from ansible.module_utils.basic import AnsibleModule
-from ..module_utils.cli_wrapper import CliCommand, StepCliExecutable
+from ..module_utils.cli_wrapper import CliCommand, CliCommandArgs, StepCliExecutable
 
 DEFAULTS_FILE = f"{os.environ.get('STEPPATH', os.environ['HOME'] + '/.step')}/config/defaults.json"
 
@@ -92,13 +92,14 @@ def run_module():
                 result["failed"] = True
             module.exit_json(**result)
 
-    bootstrap_cmd = CliCommand(cli_exec, ["ca", "bootstrap"], {
+    bootstrap_args = CliCommandArgs(["ca", "bootstrap"], {
         "ca_url": "--ca-url",
         "fingerprint": "--fingerprint",
         "force": "--force",
         "install": "--install",
         "redirect_url": "--redirect-url",
     })
+    bootstrap_cmd = CliCommand(cli_exec, bootstrap_args)
     bootstrap_cmd.run(module)
     result["changed"] = True
     module.exit_json(**result)

--- a/plugins/modules/step_ca_certificate.py
+++ b/plugins/modules/step_ca_certificate.py
@@ -267,7 +267,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.validation import check_required_if
 
 from ..module_utils.params.ca_connection import CaConnectionParams
-from ..module_utils.cli_wrapper import CliCommand, StepCliExecutable
+from ..module_utils.cli_wrapper import CliCommand, CliCommandArgs, StepCliExecutable
 from ..module_utils import helpers
 from ..module_utils.constants import DEFAULT_STEP_CLI_EXECUTABLE
 
@@ -297,10 +297,8 @@ def create_certificate(executable: StepCliExecutable, module: AnsibleModule, for
     if force:
         args.append("--force")
 
-    create_cmd = CliCommand(executable, args, {
-        **cert_cliarg_map,
-        **CaConnectionParams.cliarg_map
-    })
+    create_args = CaConnectionParams.cli_args().join(CliCommandArgs(args, cert_cliarg_map))
+    create_cmd = CliCommand(executable, create_args)
     create_cmd.run(module)
     return {"changed": True}
 
@@ -355,10 +353,8 @@ def revoke_certificate(executable: StepCliExecutable, module: AnsibleModule) -> 
         "revoke_reason_code": "--reasonCode",
         "token": "--token"
     }
-    revoke_cmd = CliCommand(executable, ["ca", "revoke"], {
-        **revoke_cliarg_map,
-        **CaConnectionParams.cliarg_map
-    }, fail_on_error=False)
+    revoke_args = CaConnectionParams.cli_args().join(CliCommandArgs(["ca", "revoke"], revoke_cliarg_map))
+    revoke_cmd = CliCommand(executable, revoke_args, fail_on_error=False)
     res = revoke_cmd.run(module)
 
     if res.rc != 0 and "is already revoked" in res.stderr:

--- a/plugins/modules/step_ca_renew.py
+++ b/plugins/modules/step_ca_renew.py
@@ -77,7 +77,7 @@ from typing import Dict, cast, Any
 
 from ansible.module_utils.basic import AnsibleModule
 
-from ..module_utils.cli_wrapper import CliCommand, StepCliExecutable
+from ..module_utils.cli_wrapper import CliCommand, CliCommandArgs, StepCliExecutable
 from ..module_utils.params.ca_connection import CaConnectionParams
 from ..module_utils.constants import DEFAULT_STEP_CLI_EXECUTABLE
 
@@ -111,10 +111,9 @@ def run_module():
     # All parameters can be converted to a mapping by just appending -- and replacing the underscores
     renew_cliarg_map = {arg: f"--{arg.replace('_', '-')}" for arg in renew_cliargs}
 
-    renew_cmd = CliCommand(executable, ["ca", "renew", module_params["crt_file"], module_params["key_file"]], {
-        **renew_cliarg_map,
-        **CaConnectionParams.cliarg_map
-    })
+    renew_args = CaConnectionParams.cli_args().join(CliCommandArgs(
+        ["ca", "renew", module_params["crt_file"], module_params["key_file"]], renew_cliarg_map))
+    renew_cmd = CliCommand(executable, renew_args)
     renew_res = renew_cmd.run(module)
     if "Your certificate has been saved in" in renew_res.stderr:
         result["changed"] = True

--- a/plugins/modules/step_ca_token.py
+++ b/plugins/modules/step_ca_token.py
@@ -141,7 +141,7 @@ from ansible.module_utils.common.validation import check_required_one_of
 from ansible.module_utils.common.validation import check_mutually_exclusive
 from ansible.module_utils.basic import AnsibleModule
 
-from ..module_utils.cli_wrapper import StepCliExecutable, CliCommand
+from ..module_utils.cli_wrapper import CliCommandArgs, StepCliExecutable, CliCommand
 from ..module_utils.params.ca_connection import CaConnectionParams
 from ..module_utils.constants import DEFAULT_STEP_CLI_EXECUTABLE
 
@@ -203,10 +203,9 @@ def run_module():
     # All parameters can be converted to a mapping by just appending -- and replacing the underscores
     token_cliarg_map = {arg: f"--{arg.replace('_', '-')}" for arg in token_cliargs}
 
-    token_cmd = CliCommand(executable, ["ca", "token", module_params["name"]], {
-        **token_cliarg_map,
-        **CaConnectionParams.cliarg_map
-    })
+    token_args = CaConnectionParams.cli_args().join(CliCommandArgs(
+        ["ca", "token", module_params["name"]], token_cliarg_map))
+    token_cmd = CliCommand(executable, token_args)
     token_res = token_cmd.run(module)
 
     result["changed"] = True

--- a/plugins/modules/step_certificate_info.py
+++ b/plugins/modules/step_certificate_info.py
@@ -101,7 +101,7 @@ from typing import cast, Dict, Any
 
 from ansible.module_utils.basic import AnsibleModule
 
-from ..module_utils.cli_wrapper import StepCliExecutable, CliCommand
+from ..module_utils.cli_wrapper import CliCommandArgs, StepCliExecutable, CliCommand
 from ..module_utils import helpers
 from ..module_utils.constants import DEFAULT_STEP_CLI_EXECUTABLE
 
@@ -135,8 +135,9 @@ def inspect_non_json(executable: StepCliExecutable, module: AnsibleModule) -> st
         "server_name": "--server-name",
         "roots": "--roots",
     }
-    cmd = CliCommand(executable, ["certificate", "inspect", module_params["path"]] +
-                     FORMAT_CLIARGS[module_params["format"]], certificate_info_cliarg_map)
+    args = CliCommandArgs(["certificate", "inspect", module_params["path"]] +
+                          FORMAT_CLIARGS[module_params["format"]], certificate_info_cliarg_map)
+    cmd = CliCommand(executable, args)
 
     # The docs say inspect outputs to stderr, but my shell says otherwise:
     # https://github.com/smallstep/cli/issues/1032


### PR DESCRIPTION
More prep work for #352, this allows module param helpers to supply a fully composable CliArgs object that can include both tempfiles and regular args