### PR TITLE
modules: add `_password` args as alternative to password_files

### DIFF
--- a/plugins/doc_fragments/ca_admin.py
+++ b/plugins/doc_fragments/ca_admin.py
@@ -20,7 +20,16 @@ class ModuleDocFragment:
         type: str
         aliases:
           - admin_name
+      admin_password:
+        description: >
+            The password to encrypt or decrypt the private key.
+            Will be passed to step-cli through a temporary file.
+            Mutually exclusive with I(admin_password_file)
+        type: str
       admin_password_file:
-        description: The path to the file containing the password to encrypt or decrypt the private key.
+        description: >
+            The path to the file containing the password to encrypt or decrypt the private key.
+            Must already be present on the remote host.
+            Mutually exclusive with I(admin_password)
         type: path
     '''

--- a/plugins/module_utils/params/ca_admin.py
+++ b/plugins/module_utils/params/ca_admin.py
@@ -17,22 +17,29 @@ class AdminParams(ParamsHelper):
         admin_key=dict(type="path"),
         admin_provisioner=dict(type="str", aliases=["admin_issuer"]),
         admin_subject=dict(type="str", aliases=["admin_name"]),
+        admin_password=dict(type="str", no_log=True),
         admin_password_file=dict(type="path", no_log=False)
     )
 
     @classmethod
     def cli_args(cls) -> CliCommandArgs:
-        return CliCommandArgs([], {key: f"--{key.replace('_', '-')}" for key in cls.argument_spec})
+        return CliCommandArgs([], {
+            "admin_cert": "--admin-cert",
+            "admin_key": "--admin-key",
+            "admin_provisioner": "--admin-provisioner",
+            "admin_subject": "--admin-subject",
+            "admin_password_file": "--admin-password-file",
+        }, {
+            "admin_password": "--admin-password-file"
+        })
 
     # pylint: disable=useless-parent-delegation
     def __init__(self, module: AnsibleModule) -> None:
         super().__init__(module)
 
     def check(self):
-        try:
-            validation.check_required_together(["admin_cert", "admin_key"], self.module.params)
-        except ValueError:
-            self.module.fail_json(msg="admin_cert and admin_key must be specified together")
+        validation.check_required_together(["admin_cert", "admin_key"], self.module.params)
+        validation.check_mutually_exclusive(["admin_password", "admin_password_file"], self.module.params)
 
     def is_defined(self):
         return bool(self.module.params["admin_cert"])  # type: ignore

--- a/tests/integration/targets/step_ca_certificate/tasks/main.yml
+++ b/tests/integration/targets/step_ca_certificate/tasks/main.yml
@@ -3,191 +3,191 @@
     key_file: "/tmp/key.pem"
 
 - block:
-  - name: Create normal certificate on CA
-    maxhoesel.smallstep.step_ca_certificate:
-      name: "127.0.0.1"
-      crt_file: "{{ crt_file }}"
-      key_file: "{{ key_file }}"
-      provisioner: "{{ ca_provisioner }}"
-      provisioner_password_file: "{{ ca_provisioner_password_file }}"
-      san:
-        - foo.bar
-      kty: RSA
-      size: 4096
-      not_after: 3h
+    - name: Create normal certificate on CA
+      maxhoesel.smallstep.step_ca_certificate:
+        name: "127.0.0.1"
+        crt_file: "{{ crt_file }}"
+        key_file: "{{ key_file }}"
+        provisioner: "{{ ca_provisioner }}"
+        provisioner_password_file: "{{ ca_provisioner_password_file }}"
+        san:
+          - foo.bar
+        kty: RSA
+        size: 4096
+        not_after: 3h
 
-  - name: Certificate is still present (idempotency check)
-    maxhoesel.smallstep.step_ca_certificate:
-      name: "127.0.0.1"
-      crt_file: "{{ crt_file }}"
-      key_file: "{{ key_file }}"
-      provisioner: "{{ ca_provisioner }}"
-      provisioner_password_file: "{{ ca_provisioner_password_file }}"
-      san:
-        - foo.bar
-      kty: RSA
-      size: 4096
-      not_after: 3h
-      verify_roots: "/root/.step/certs/root_ca.crt"
-    register: cert_idempotency
-  - name: Check that cert did not change
-    ansible.builtin.assert:
-      that: not cert_idempotency.changed
+    - name: Certificate is still present (idempotency check)
+      maxhoesel.smallstep.step_ca_certificate:
+        name: "127.0.0.1"
+        crt_file: "{{ crt_file }}"
+        key_file: "{{ key_file }}"
+        provisioner: "{{ ca_provisioner }}"
+        provisioner_password_file: "{{ ca_provisioner_password_file }}"
+        san:
+          - foo.bar
+        kty: RSA
+        size: 4096
+        not_after: 3h
+        verify_roots: "/root/.step/certs/root_ca.crt"
+      register: cert_idempotency
+    - name: Check that cert did not change
+      ansible.builtin.assert:
+        that: not cert_idempotency.changed
 
-  - name: Certificate stays the same if parameters are omitted
-    maxhoesel.smallstep.step_ca_certificate:
-      name: "127.0.0.1"
-      crt_file: "{{ crt_file }}"
-      key_file: "{{ key_file }}"
-      provisioner: "{{ ca_provisioner }}"
-      provisioner_password_file: "{{ ca_provisioner_password_file }}"
-      verify_roots: "/root/.step/certs/root_ca.crt"
-    register: cert_missing_parameters_idempotency
-  - name: Check that cert did not change
-    ansible.builtin.assert:
-      that: not cert_missing_parameters_idempotency.changed
+    - name: Certificate stays the same if parameters are omitted
+      maxhoesel.smallstep.step_ca_certificate:
+        name: "127.0.0.1"
+        crt_file: "{{ crt_file }}"
+        key_file: "{{ key_file }}"
+        provisioner: "{{ ca_provisioner }}"
+        provisioner_password_file: "{{ ca_provisioner_password_file }}"
+        verify_roots: "/root/.step/certs/root_ca.crt"
+      register: cert_missing_parameters_idempotency
+    - name: Check that cert did not change
+      ansible.builtin.assert:
+        that: not cert_missing_parameters_idempotency.changed
 
-  - name: Certificate gets reissued on force
-    maxhoesel.smallstep.step_ca_certificate:
-      force: true
-      name: "127.0.0.1"
-      crt_file: "{{ crt_file }}"
-      key_file: "{{ key_file }}"
-      provisioner: "{{ ca_provisioner }}"
-      provisioner_password_file: "{{ ca_provisioner_password_file }}"
-      san:
-        - foo.bar
-      kty: RSA
-      size: 4096
-      not_after: 3h
-      verify_roots: "/root/.step/certs/root_ca.crt"
-    register: cert_force
-  - name: Check that cert changed
-    ansible.builtin.assert:
-      that: cert_force.changed
+    - name: Certificate gets reissued on force
+      maxhoesel.smallstep.step_ca_certificate:
+        force: true
+        name: "127.0.0.1"
+        crt_file: "{{ crt_file }}"
+        key_file: "{{ key_file }}"
+        provisioner: "{{ ca_provisioner }}"
+        provisioner_password: "{{ ca_provisioner_password }}"
+        san:
+          - foo.bar
+        kty: RSA
+        size: 4096
+        not_after: 3h
+        verify_roots: "/root/.step/certs/root_ca.crt"
+      register: cert_force
+    - name: Check that cert changed
+      ansible.builtin.assert:
+        that: cert_force.changed
 
-  - name: Certificate gets reissued on SAN change
-    maxhoesel.smallstep.step_ca_certificate:
-      name: "127.0.0.1"
-      crt_file: "{{ crt_file }}"
-      key_file: "{{ key_file }}"
-      provisioner: "{{ ca_provisioner }}"
-      provisioner_password_file: "{{ ca_provisioner_password_file }}"
-      san:
-        - foo.bar
-        - another.san
-      kty: RSA
-      size: 4096
-      not_after: 3h
-      verify_roots: "/root/.step/certs/root_ca.crt"
-    register: cert_san
-  - name: Check that cert changed
-    ansible.builtin.assert:
-      that: cert_san.changed
+    - name: Certificate gets reissued on SAN change
+      maxhoesel.smallstep.step_ca_certificate:
+        name: "127.0.0.1"
+        crt_file: "{{ crt_file }}"
+        key_file: "{{ key_file }}"
+        provisioner: "{{ ca_provisioner }}"
+        provisioner_password: "{{ ca_provisioner_password }}"
+        san:
+          - foo.bar
+          - another.san
+        kty: RSA
+        size: 4096
+        not_after: 3h
+        verify_roots: "/root/.step/certs/root_ca.crt"
+      register: cert_san
+    - name: Check that cert changed
+      ansible.builtin.assert:
+        that: cert_san.changed
 
-  - name: Certificate gets reissued on size change
-    maxhoesel.smallstep.step_ca_certificate:
-      name: "127.0.0.1"
-      crt_file: "{{ crt_file }}"
-      key_file: "{{ key_file }}"
-      provisioner: "{{ ca_provisioner }}"
-      provisioner_password_file: "{{ ca_provisioner_password_file }}"
-      san:
-        - foo.bar
-        - another.san
-      kty: RSA
-      size: 2048
-      not_after: 3h
-      verify_roots: "/root/.step/certs/root_ca.crt"
-    register: cert_size
-  - name: Check that cert changed
-    ansible.builtin.assert:
-      that: cert_size.changed
+    - name: Certificate gets reissued on size change
+      maxhoesel.smallstep.step_ca_certificate:
+        name: "127.0.0.1"
+        crt_file: "{{ crt_file }}"
+        key_file: "{{ key_file }}"
+        provisioner: "{{ ca_provisioner }}"
+        provisioner_password: "{{ ca_provisioner_password }}"
+        san:
+          - foo.bar
+          - another.san
+        kty: RSA
+        size: 2048
+        not_after: 3h
+        verify_roots: "/root/.step/certs/root_ca.crt"
+      register: cert_size
+    - name: Check that cert changed
+      ansible.builtin.assert:
+        that: cert_size.changed
 
-  - name: Certificate gets reissued on kty change
-    maxhoesel.smallstep.step_ca_certificate:
-      name: "127.0.0.1"
-      crt_file: "{{ crt_file }}"
-      key_file: "{{ key_file }}"
-      provisioner: "{{ ca_provisioner }}"
-      provisioner_password_file: "{{ ca_provisioner_password_file }}"
-      san:
-        - foo.bar
-        - another.san
-      kty: EC
-      not_after: 3h
-      verify_roots: "/root/.step/certs/root_ca.crt"
-    register: cert_kty
-  - name: Check that cert changed
-    ansible.builtin.assert:
-      that: cert_kty.changed
+    - name: Certificate gets reissued on kty change
+      maxhoesel.smallstep.step_ca_certificate:
+        name: "127.0.0.1"
+        crt_file: "{{ crt_file }}"
+        key_file: "{{ key_file }}"
+        provisioner: "{{ ca_provisioner }}"
+        provisioner_password: "{{ ca_provisioner_password }}"
+        san:
+          - foo.bar
+          - another.san
+        kty: EC
+        not_after: 3h
+        verify_roots: "/root/.step/certs/root_ca.crt"
+      register: cert_kty
+    - name: Check that cert changed
+      ansible.builtin.assert:
+        that: cert_kty.changed
 
-  - name: Certificate gets reissued on crv change
-    maxhoesel.smallstep.step_ca_certificate:
-      name: "127.0.0.1"
-      crt_file: "{{ crt_file }}"
-      key_file: "{{ key_file }}"
-      provisioner: "{{ ca_provisioner }}"
-      provisioner_password_file: "{{ ca_provisioner_password_file }}"
-      san:
-        - foo.bar
-        - another.san
-      kty: EC
-      crv: P-521
-      not_after: 3h
-      verify_roots: "/root/.step/certs/root_ca.crt"
-    register: cert_crv
-  - name: Check that cert changed
-    ansible.builtin.assert:
-      that: cert_crv.changed
+    - name: Certificate gets reissued on crv change
+      maxhoesel.smallstep.step_ca_certificate:
+        name: "127.0.0.1"
+        crt_file: "{{ crt_file }}"
+        key_file: "{{ key_file }}"
+        provisioner: "{{ ca_provisioner }}"
+        provisioner_password: "{{ ca_provisioner_password }}"
+        san:
+          - foo.bar
+          - another.san
+        kty: EC
+        crv: P-521
+        not_after: 3h
+        verify_roots: "/root/.step/certs/root_ca.crt"
+      register: cert_crv
+    - name: Check that cert changed
+      ansible.builtin.assert:
+        that: cert_crv.changed
 
-  - name: Revoke certificate
-    maxhoesel.smallstep.step_ca_certificate:
-      crt_file: "{{ crt_file }}"
-      key_file: "{{ key_file }}"
-      state: revoked
-    register: revoked
-  - name: Check that cert got revoked
-    ansible.builtin.assert:
-      that: revoked.changed
+    - name: Revoke certificate
+      maxhoesel.smallstep.step_ca_certificate:
+        crt_file: "{{ crt_file }}"
+        key_file: "{{ key_file }}"
+        state: revoked
+      register: revoked
+    - name: Check that cert got revoked
+      ansible.builtin.assert:
+        that: revoked.changed
 
-  - name: Revoke certificate again
-    maxhoesel.smallstep.step_ca_certificate:
-      crt_file: "{{ crt_file }}"
-      key_file: "{{ key_file }}"
-      state: revoked
-    register: revoked_again
-  - name: Check that cert revocation didn't change
-    ansible.builtin.assert:
-      that: not revoked_again.changed
+    - name: Revoke certificate again
+      maxhoesel.smallstep.step_ca_certificate:
+        crt_file: "{{ crt_file }}"
+        key_file: "{{ key_file }}"
+        state: revoked
+      register: revoked_again
+    - name: Check that cert revocation didn't change
+      ansible.builtin.assert:
+        that: not revoked_again.changed
 
-  - name: Delete certificate
-    maxhoesel.smallstep.step_ca_certificate:
-      crt_file: "{{ crt_file }}"
-      key_file: "{{ key_file }}"
-      revoke_on_delete: true # already the default
-      state: absent
-    register: deleted
-  - name: Check that cert got deleted
-    ansible.builtin.assert:
-      that: revoked.changed
+    - name: Delete certificate
+      maxhoesel.smallstep.step_ca_certificate:
+        crt_file: "{{ crt_file }}"
+        key_file: "{{ key_file }}"
+        revoke_on_delete: true # already the default
+        state: absent
+      register: deleted
+    - name: Check that cert got deleted
+      ansible.builtin.assert:
+        that: revoked.changed
 
-  - name: Delete certificate again
-    maxhoesel.smallstep.step_ca_certificate:
-      crt_file: "{{ crt_file }}"
-      key_file: "{{ key_file }}"
-      revoke_on_delete: true # already the default
-      state: absent
-    register: deleted_again
-  - name: Check that cert did not change
-    ansible.builtin.assert:
-      that: not deleted_again.changed
+    - name: Delete certificate again
+      maxhoesel.smallstep.step_ca_certificate:
+        crt_file: "{{ crt_file }}"
+        key_file: "{{ key_file }}"
+        revoke_on_delete: true # already the default
+        state: absent
+      register: deleted_again
+    - name: Check that cert did not change
+      ansible.builtin.assert:
+        that: not deleted_again.changed
 
   always:
-  - name: Delete generated files
-    file:
-      path: "{{ item }}"
-      state: absent
-    loop:
-      - "{{ crt_file }}"
-      - "{{ key_file }}"
+    - name: Delete generated files
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ crt_file }}"
+        - "{{ key_file }}"

--- a/tests/integration/targets/step_ca_provisioner/tasks/main.yml
+++ b/tests/integration/targets/step_ca_provisioner/tasks/main.yml
@@ -1,162 +1,166 @@
 - block:
-  - name: Testing keys are present
-    copy:
-      src: "{{ item }}"
-      dest: "/tmp/"
-      owner: "{{ ca_user }}"
-      group: "{{ ca_user }}"
-      mode: 0600
-    loop:
-      - tests_key
-      - tests_crt
+    - name: Testing keys are present
+      copy:
+        src: "{{ item }}"
+        dest: "/tmp/"
+        owner: "{{ ca_user }}"
+        group: "{{ ca_user }}"
+        mode: 0600
+      loop:
+        - tests_key
+        - tests_crt
 
-  - name: Testing password file is present
-    copy:
-      content: "password-testing"
-      dest: "/tmp/tests_passfile"
-      owner: "{{ ca_user }}"
-      group: "{{ ca_user }}"
-      mode: 0644 # needs to be readable by the client requesting the cert
+    - name: Testing password file is present
+      copy:
+        content: "password-testing"
+        dest: "/tmp/tests_passfile"
+        owner: "{{ ca_user }}"
+        group: "{{ ca_user }}"
+        mode: 0644 # needs to be readable by the client requesting the cert
 
-  # The values for these test provisioners are mostly identical to the ones in the smallstep documentation,
-  # so many of the online provisioners do not actually work. Good enough to test our module
-  # functionality still.
-  - name: Create test provisioners
-    maxhoesel.smallstep.step_ca_provisioner: "{{ item | combine({'step_cli_executable': cli_binary}) }}"
-    loop:
-      - name: tests-JWK
-        type: JWK
-        password_file: "/tmp/tests_passfile"
-        create: yes
-      - name: tests-OIDC
+    # The values for these test provisioners are mostly identical to the ones in the smallstep documentation,
+    # so many of the online provisioners do not actually work. Good enough to test our module
+    # functionality still.
+    - name: Create test provisioners
+      maxhoesel.smallstep.step_ca_provisioner: "{{ item | combine({'step_cli_executable': cli_binary}) }}"
+      loop:
+        - name: tests-JWK
+          type: JWK
+          password_file: "/tmp/tests_passfile"
+          create: yes
+        - name: tests-JWK-passfile
+          type: JWK
+          password: "flightofthefirebird"
+          create: yes
+        - name: tests-OIDC
+          type: OIDC
+          oidc_client_id: 1087160488420-8qt7bavg3qesdhs6it824mhnfgcfe8il.apps.googleusercontent.com
+          oidc_configuration_endpoint: https://accounts.google.com/.well-known/openid-configuration
+          oidc_admin_email:
+            - mariano@smallstep.com
+            - max@smallstep.com
+        - name: tests-Amazon
+          type: AWS
+          aws_account: 123456789
+          instance_age: 1h
+        - name: tests-Google
+          type: GCP
+          gcp_service_account:
+            - 1234567890-compute@developer.gserviceaccount.com
+            - 9876543210-compute@developer.gserviceaccount.com
+          gcp_project:
+            - identity
+            - accounting
+        - name: tests-ACME
+          type: ACME
+        - name: tests-x5c
+          type: X5C
+          x5c_root_file: "/tmp/tests_crt"
+        - name: tests-k8s
+          type: K8SSA
+          k8s_pem_keys_file: "/tmp/tests_crt"
+
+    - name: Test creation idempotency
+      maxhoesel.smallstep.step_ca_provisioner: "{{ item | combine({'step_cli_executable': cli_binary })}}"
+      loop:
+        - name: tests-JWK
+          type: JWK
+          create: yes
+          password_file: "/tmp/tests_passfile"
+        - name: tests-OIDC
+          type: OIDC
+          oidc_client_id: 1087160488420-8qt7bavg3qesdhs6it824mhnfgcfe8il.apps.googleusercontent.com
+          oidc_configuration_endpoint: https://accounts.google.com/.well-known/openid-configuration
+          oidc_admin_email:
+            - mariano@smallstep.com
+            - max@smallstep.com
+        - name: tests-Amazon
+          type: AWS
+          aws_account: 123456789
+          instance_age: 1h
+        - name: tests-Google
+          type: GCP
+          gcp_service_account:
+            - 1234567890-compute@developer.gserviceaccount.com
+            - 9876543210-compute@developer.gserviceaccount.com
+          gcp_project:
+            - identity
+            - accounting
+        - name: tests-ACME
+          type: ACME
+        - name: tests-x5c
+          type: X5C
+          x5c_root_file: "/tmp/tests_crt"
+        - name: tests-k8s
+          type: K8SSA
+          k8s_pem_keys_file: "/tmp/tests_crt"
+      register: second_run
+
+    - name: Verify that nothing changed on the second run
+      assert:
+        that: not second_run.changed
+
+    - name: Test updating provisioners
+      maxhoesel.smallstep.step_ca_provisioner:
+        name: tests-OIDC
         type: OIDC
         oidc_client_id: 1087160488420-8qt7bavg3qesdhs6it824mhnfgcfe8il.apps.googleusercontent.com
         oidc_configuration_endpoint: https://accounts.google.com/.well-known/openid-configuration
         oidc_admin_email:
           - mariano@smallstep.com
           - max@smallstep.com
-      - name: tests-Amazon
-        type: AWS
-        aws_account: 123456789
-        instance_age: 1h
-      - name: tests-Google
-        type: GCP
-        gcp_service_account:
-          - 1234567890-compute@developer.gserviceaccount.com
-          - 9876543210-compute@developer.gserviceaccount.com
-        gcp_project:
-          - identity
-          - accounting
-      - name: tests-ACME
-        type: ACME
-      - name: tests-x5c
-        type: X5C
-        x5c_root_file: "/tmp/tests_crt"
-      - name: tests-k8s
-        type: K8SSA
-        k8s_pem_keys_file: "/tmp/tests_crt"
+          - new@admin.com
+        state: "updated"
+        step_cli_executable: "{{ cli_binary }}"
+      register: update_test
 
-  - name: Test creation idempotency
-    maxhoesel.smallstep.step_ca_provisioner: "{{ item | combine({'step_cli_executable': cli_binary })}}"
-    loop:
-      - name: tests-JWK
-        type: JWK
-        create: yes
-        password_file: "/tmp/tests_passfile"
-      - name: tests-OIDC
-        type: OIDC
-        oidc_client_id: 1087160488420-8qt7bavg3qesdhs6it824mhnfgcfe8il.apps.googleusercontent.com
-        oidc_configuration_endpoint: https://accounts.google.com/.well-known/openid-configuration
-        oidc_admin_email:
-          - mariano@smallstep.com
-          - max@smallstep.com
-      - name: tests-Amazon
-        type: AWS
-        aws_account: 123456789
-        instance_age: 1h
-      - name: tests-Google
-        type: GCP
-        gcp_service_account:
-          - 1234567890-compute@developer.gserviceaccount.com
-          - 9876543210-compute@developer.gserviceaccount.com
-        gcp_project:
-          - identity
-          - accounting
-      - name: tests-ACME
-        type: ACME
-      - name: tests-x5c
-        type: X5C
-        x5c_root_file: "/tmp/tests_crt"
-      - name: tests-k8s
-        type: K8SSA
-        k8s_pem_keys_file: "/tmp/tests_crt"
-    register: second_run
+    - name: Verify that provisioner got updated
+      ansible.builtin.assert:
+        that: update_test.changed
 
-  - name: Verify that nothing changed on the second run
-    assert:
-      that: not second_run.changed
+    # Remove the online provisioners before restarting as they may imapct server
+    # functionality
+    - name: Remove online provisioners
+      maxhoesel.smallstep.step_ca_provisioner:
+        name: "{{ item.0 }}"
+        type: "{{ item.1 }}"
+        state: absent
+        step_cli_executable: "{{ cli_binary }}"
+      loop:
+        - ["tests-OIDC", "OIDC"]
+        - ["tests-Amazon", "AWS"]
+        - ["tests-Google", "GCP"]
 
-  - name: Test updating provisioners
-    maxhoesel.smallstep.step_ca_provisioner:
-      name: tests-OIDC
-      type: OIDC
-      oidc_client_id: 1087160488420-8qt7bavg3qesdhs6it824mhnfgcfe8il.apps.googleusercontent.com
-      oidc_configuration_endpoint: https://accounts.google.com/.well-known/openid-configuration
-      oidc_admin_email:
-        - mariano@smallstep.com
-        - max@smallstep.com
-        - new@admin.com
-      state: "updated"
-      step_cli_executable: "{{ cli_binary }}"
-    register: update_test
+    - name: Get Server PID
+      shell: pgrep -fa step-ca | grep -v step-ca.sh | cut -d ' ' -f 1
+      register: _pid
+    - name: Reload Server
+      command: "kill -1 {{ _pid.stdout_lines[0] }}"
+      become: false
 
-  - name: Verify that provisioner got updated
-    ansible.builtin.assert:
-      that:
-        update_test.changed
+    - name: Check server health
+      command: "{{ cli_binary }} ca health"
+      changed_when: no
 
-  # Remove the online provisioners before restarting as they may imapct server
-  # functionality
-  - name: Remove online provisioners
-    maxhoesel.smallstep.step_ca_provisioner:
-      name: "{{ item.0 }}"
-      type: "{{ item.1 }}"
-      state: absent
-      step_cli_executable: "{{ cli_binary }}"
-    loop:
-      - ["tests-OIDC", "OIDC"]
-      - ["tests-Amazon", "AWS"]
-      - ["tests-Google", "GCP"]
+    - name: Remove test provisioners
+      maxhoesel.smallstep.step_ca_provisioner:
+        name: "{{ item }}"
+        state: absent
+        step_cli_executable: "{{ cli_binary }}"
+      loop:
+        - "tests-JWK"
+        - "tests-JWK-passfile"
+        - "tests-ACME"
+        - "tests-x5c"
+        - "tests-k8s"
 
-  - name: Get Server PID
-    shell: pgrep -fa step-ca | grep -v step-ca.sh | cut -d ' ' -f 1
-    register: _pid
-  - name: Reload Server
-    command: "kill -1 {{ _pid.stdout_lines[0] }}"
-    become: false
-
-  - name: Check server health
-    command: "{{ cli_binary }} ca health"
-    changed_when: no
-
-  - name: Remove test provisioners
-    maxhoesel.smallstep.step_ca_provisioner:
-      name: "{{ item }}"
-      state: absent
-      step_cli_executable: "{{ cli_binary }}"
-    loop:
-      - "tests-JWK"
-      - "tests-ACME"
-      - "tests-x5c"
-      - "tests-k8s"
-
-  - name: Get step-ca config
-    command: "cat {{ ca_path }}/config/ca.json"
-    register: step_ca_config
-  - name: Verify that all provisioners are absent
-    assert:
-      that:
-        - (step_ca_config.stdout | from_json).authority.provisioners is not defined
+    - name: Get step-ca config
+      command: "cat {{ ca_path }}/config/ca.json"
+      register: step_ca_config
+    - name: Verify that all provisioners are absent
+      assert:
+        that:
+          - (step_ca_config.stdout | from_json).authority.provisioners is not defined
   become: yes
   become_user: "{{ ca_user }}"
   environment:

--- a/tests/integration/targets/step_ca_renew/tasks/main.yml
+++ b/tests/integration/targets/step_ca_renew/tasks/main.yml
@@ -12,6 +12,7 @@
   maxhoesel.smallstep.step_ca_renew:
     crt_file: /tmp/generated_certificate
     key_file: /tmp/generated_key
+    password_file: "{{ ca_provisioner_password_file }}"
     expires_in: 5m
     force: yes
   register: early_renewal
@@ -24,6 +25,7 @@
   maxhoesel.smallstep.step_ca_renew:
     crt_file: /tmp/generated_certificate
     key_file: /tmp/generated_key
+    password: "{{ ca_provisioner_password }}"
     force: yes
     expires_in: 61m
   register: forced_renewal

--- a/tests/integration/targets/step_ca_token/tasks/main.yml
+++ b/tests/integration/targets/step_ca_token/tasks/main.yml
@@ -9,3 +9,11 @@
 - name: Verify that token got returned
   assert:
     that: generated_token.token
+
+- name: Test token creation with direct provisioner password
+  maxhoesel.smallstep.step_ca_token:
+    name: "127.0.0.1"
+    provisioner: "{{ ca_provisioner }}"
+    provisioner_password: "{{ ca_provisioner_password }}"
+    return_token: yes
+  register: generated_token


### PR DESCRIPTION
this PR adds a `_password` parameter to go along with every currently existing `password_file` module parameter. As discussed in #352, this makes passing in passwords to tasks much more convenient, as users no longer need to create and delete password files manually.

To ensure no sensitive password files remain on the system, they are created in a temporary directory that is handled through a context manager, see #398.

fixes #352 