### PR TITLE
roles: bump supported distributions

### DIFF
--- a/roles/step_acme_cert/README.md
+++ b/roles/step_acme_cert/README.md
@@ -13,9 +13,9 @@ The advantage of the `step` method is that no additional tools are required.
 ## Requirements
 
 - The following distributions are currently supported and tested:
-  - Ubuntu: `20.04 LTS, 22.04 LTS`
+  - Ubuntu: `20.04 LTS, 22.04 LTS, 24.04 LTS`
   - Debian: `11, 12`
-  - Fedora: `38, 39`
+  - Fedora: `39, 40`
   - RHEL(-compatible): `9` (RockyLinux is used for testing)
   - Other distributions may work as well, but are not tested
 - Running this role requires root access. Make sure to run this role with `become: yes` or equivalent

--- a/roles/step_acme_cert/molecule/default/molecule.yml
+++ b/roles/step_acme_cert/molecule/default/molecule.yml
@@ -13,6 +13,20 @@ platforms:
     networks:
       - name: molecule-step-acme-cert
 
+  - name: step-host-ubuntu-24
+    groups:
+      - clients
+      - ubuntu
+    image: "docker.io/geerlingguy/docker-ubuntu2404-ansible"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    override_command: false
+    pre_build_image: true
+    networks:
+      - name: molecule-step-acme-cert
+
   - name: step-host-ubuntu-22
     groups:
       - clients
@@ -83,11 +97,11 @@ platforms:
     networks:
       - name: molecule-step-acme-cert
 
-  - name: step-host-fedora-39
+  - name: step-host-fedora-40
     groups:
       - clients
       - fedora
-    image: "docker.io/geerlingguy/docker-fedora39-ansible"
+    image: "docker.io/geerlingguy/docker-fedora40-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -97,11 +111,11 @@ platforms:
     networks:
       - name: molecule-step-acme-cert
 
-  - name: step-host-fedora-38
+  - name: step-host-fedora-39
     groups:
       - clients
       - fedora
-    image: "docker.io/geerlingguy/docker-fedora38-ansible"
+    image: "docker.io/geerlingguy/docker-fedora39-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/step_acme_cert/molecule/non_root/molecule.yml
+++ b/roles/step_acme_cert/molecule/non_root/molecule.yml
@@ -13,6 +13,20 @@ platforms:
     networks:
       - name: molecule-step-acme-cert
 
+  - name: step-host-ubuntu-24
+    groups:
+      - clients
+      - ubuntu
+    image: "docker.io/geerlingguy/docker-ubuntu2404-ansible"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    override_command: false
+    pre_build_image: true
+    networks:
+      - name: molecule-step-acme-cert
+
   - name: step-host-ubuntu-22
     groups:
       - clients
@@ -83,11 +97,11 @@ platforms:
     networks:
       - name: molecule-step-acme-cert
 
-  - name: step-host-fedora-39
+  - name: step-host-fedora-40
     groups:
       - clients
       - fedora
-    image: "docker.io/geerlingguy/docker-fedora39-ansible"
+    image: "docker.io/geerlingguy/docker-fedora40-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -97,11 +111,11 @@ platforms:
     networks:
       - name: molecule-step-acme-cert
 
-  - name: step-host-fedora-38
+  - name: step-host-fedora-39
     groups:
       - clients
       - fedora
-    image: "docker.io/geerlingguy/docker-fedora38-ansible"
+    image: "docker.io/geerlingguy/docker-fedora39-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/step_bootstrap_host/README.md
+++ b/roles/step_bootstrap_host/README.md
@@ -11,9 +11,9 @@ It will:
 ## Requirements
 
 - The following distributions are currently supported and tested:
-  - Ubuntu: `20.04 LTS, 22.04 LTS`
+  - Ubuntu: `20.04 LTS, 22.04 LTS, 24.04 LTS`
   - Debian: `11, 12`
-  - Fedora: `38, 39`
+  - Fedora: `39, 40`
   - RHEL(-compatible): `9` (RockyLinux is used for testing)
   - Other distributions may work as well, but are not tested
 - This role requires root access. Make sure to run this role with `become: yes` or equivalent

--- a/roles/step_bootstrap_host/molecule/default/molecule.yml
+++ b/roles/step_bootstrap_host/molecule/default/molecule.yml
@@ -14,6 +14,20 @@ platforms:
     networks:
       - name: molecule-step-bootstrap-host
 
+  - name: step-host-ubuntu-24
+    groups:
+      - clients
+      - ubuntu
+    image: "docker.io/geerlingguy/docker-ubuntu2404-ansible"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    override_command: false
+    pre_build_image: true
+    networks:
+      - name: molecule-step-bootstrap-host
+
   - name: step-host-ubuntu-22
     groups:
       - clients
@@ -84,11 +98,11 @@ platforms:
     networks:
       - name: molecule-step-bootstrap-host
 
-  - name: step-host-fedora-39
+  - name: step-host-fedora-40
     groups:
       - clients
       - fedora
-    image: "docker.io/geerlingguy/docker-fedora39-ansible"
+    image: "docker.io/geerlingguy/docker-fedora40-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -98,11 +112,11 @@ platforms:
     networks:
       - name: molecule-step-bootstrap-host
 
-  - name: step-host-fedora-38
+  - name: step-host-fedora-39
     groups:
       - clients
       - fedora
-    image: "docker.io/geerlingguy/docker-fedora38-ansible"
+    image: "docker.io/geerlingguy/docker-fedora39-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/step_bootstrap_host/molecule/multi_user/molecule.yml
+++ b/roles/step_bootstrap_host/molecule/multi_user/molecule.yml
@@ -14,6 +14,20 @@ platforms:
     networks:
       - name: molecule-step-bootstrap-host
 
+  - name: step-host-ubuntu-24
+    groups:
+      - clients
+      - ubuntu
+    image: "docker.io/geerlingguy/docker-ubuntu2404-ansible"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    override_command: false
+    pre_build_image: true
+    networks:
+      - name: molecule-step-bootstrap-host
+
   - name: step-host-ubuntu-22
     groups:
       - clients
@@ -84,11 +98,11 @@ platforms:
     networks:
       - name: molecule-step-bootstrap-host
 
-  - name: step-host-fedora-39
+  - name: step-host-fedora-40
     groups:
       - clients
       - fedora
-    image: "docker.io/geerlingguy/docker-fedora39-ansible"
+    image: "docker.io/geerlingguy/docker-fedora40-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -98,11 +112,11 @@ platforms:
     networks:
       - name: molecule-step-bootstrap-host
 
-  - name: step-host-fedora-38
+  - name: step-host-fedora-39
     groups:
       - clients
       - fedora
-    image: "docker.io/geerlingguy/docker-fedora38-ansible"
+    image: "docker.io/geerlingguy/docker-fedora39-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/step_ca/README.md
+++ b/roles/step_ca/README.md
@@ -30,9 +30,9 @@ It is thus **very** important that you **back up your root key and password** in
 ## Requirements
 
 - The following distributions are currently supported and tested:
-  - Ubuntu: `20.04 LTS, 22.04 LTS`
+  - Ubuntu: `20.04 LTS, 22.04 LTS, 24.04 LTS`
   - Debian: `11, 12`
-  - Fedora: `38, 39`
+  - Fedora: `39, 40`
   - RHEL(-compatible): `9` (RockyLinux is used for testing)
   - Other distributions may work as well, but are not tested
 - Supported architectures: amd64, arm64

--- a/roles/step_ca/molecule/default/molecule.yml
+++ b/roles/step_ca/molecule/default/molecule.yml
@@ -1,4 +1,16 @@
 platforms:
+  - name: step-ca-ubuntu-24
+    groups:
+      - ubuntu
+      - ca
+    image: "docker.io/geerlingguy/docker-ubuntu2404-ansible"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    override_command: false
+    pre_build_image: true
+
   - name: step-ca-ubuntu-22
     groups:
       - ubuntu
@@ -59,11 +71,11 @@ platforms:
     override_command: false
     pre_build_image: true
 
-  - name: step-ca-fedora-39
+  - name: step-ca-fedora-40
     groups:
       - fedora
       - ca
-    image: "docker.io/geerlingguy/docker-fedora39-ansible"
+    image: "docker.io/geerlingguy/docker-fedora40-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -71,11 +83,11 @@ platforms:
     override_command: false
     pre_build_image: true
 
-  - name: step-ca-fedora-38
+  - name: step-ca-fedora-39
     groups:
       - fedora
       - ca
-    image: "docker.io/geerlingguy/docker-fedora38-ansible"
+    image: "docker.io/geerlingguy/docker-fedora39-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/step_cli/README.md
+++ b/roles/step_cli/README.md
@@ -7,9 +7,9 @@ This role is used by `step_bootstrap_host` and `step_ca`, but can also be used s
 ## Requirements
 
 - The following distributions are currently supported and tested:
-  - Ubuntu: `20.04 LTS, 22.04 LTS`
+  - Ubuntu: `20.04 LTS, 22.04 LTS, 24.04 LTS`
   - Debian: `11, 12`
-  - Fedora: `38, 39`
+  - Fedora: `39, 40`
   - RHEL(-compatible): `9` (RockyLinux is used for testing)
   - Other distributions may work as well, but are not tested
 - Supported architectures: amd64, arm64

--- a/roles/step_cli/molecule/default/molecule.yml
+++ b/roles/step_cli/molecule/default/molecule.yml
@@ -1,4 +1,15 @@
 platforms:
+  - name: step-cli-ubuntu-24
+    image: "docker.io/geerlingguy/docker-ubuntu2404-ansible"
+    groups:
+      - ubuntu
+    override_command: false
+    pre_build_image: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+
   - name: step-cli-ubuntu-22
     image: "docker.io/geerlingguy/docker-ubuntu2204-ansible"
     groups:
@@ -54,19 +65,8 @@ platforms:
     cgroupns_mode: host
     privileged: true
 
-  - name: step-cli-rockylinux-8
-    image: "docker.io/geerlingguy/docker-rockylinux8-ansible"
-    groups:
-      - rockylinux
-    override_command: false
-    pre_build_image: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-
-  - name: step-cli-fedora-39
-    image: "docker.io/geerlingguy/docker-fedora39-ansible"
+  - name: step-cli-fedora-40
+    image: "docker.io/geerlingguy/docker-fedora40-ansible"
     groups:
       - fedora
     override_command: false
@@ -76,8 +76,8 @@ platforms:
     cgroupns_mode: host
     privileged: true
 
-  - name: step-cli-fedora-38
-    image: "docker.io/geerlingguy/docker-fedora38-ansible"
+  - name: step-cli-fedora-39
+    image: "docker.io/geerlingguy/docker-fedora39-ansible"
     groups:
       - fedora
     override_command: false


### PR DESCRIPTION
This path updates the tested fedora and ubuntu versions to be in line with current releases