### PR TITLE
Restart renewal service after issuing new cert with CA, reload affected services

### DIFF
--- a/roles/step_acme_cert/handlers/main.yml
+++ b/roles/step_acme_cert/handlers/main.yml
@@ -6,3 +6,4 @@
 - name: reload affected services
   command: systemctl try-reload-or-restart {{ step_acme_cert_renewal_reload_services | join(' ') }}
   when: step_acme_cert_renewal_reload_services
+  ignore_errors: true

--- a/roles/step_acme_cert/handlers/main.yml
+++ b/roles/step_acme_cert/handlers/main.yml
@@ -2,3 +2,7 @@
   service:
     name: '{{ step_acme_cert_renewal_service }}'
     state: restarted
+
+- name: reload affected services
+  command: systemctl try-reload-or-restart {{ step_acme_cert_renewal_reload_services | join(' ') }}
+  when: step_acme_cert_renewal_reload_services

--- a/roles/step_acme_cert/tasks/main.yml
+++ b/roles/step_acme_cert/tasks/main.yml
@@ -29,6 +29,7 @@
   become_user: "{{ step_acme_cert_user }}"
   environment:
     STEPPATH: "{{ _resolved_steppath }}"
+  notify: restart renewal service
 
 - name: Cert and key permissions are set
   file:

--- a/roles/step_acme_cert/tasks/main.yml
+++ b/roles/step_acme_cert/tasks/main.yml
@@ -29,7 +29,9 @@
   become_user: "{{ step_acme_cert_user }}"
   environment:
     STEPPATH: "{{ _resolved_steppath }}"
-  notify: restart renewal service
+  notify:
+    - reload affected services
+    - restart renewal service
 
 - name: Cert and key permissions are set
   file:


### PR DESCRIPTION
This fixes #450 by always restarting the `step-renew` service after certificate re-issuance, and reloading desired services just like the `step-renew` service would.